### PR TITLE
fix: config file flag refactor

### DIFF
--- a/v1/cmd/foundry/commands/cluster/init.go
+++ b/v1/cmd/foundry/commands/cluster/init.go
@@ -45,12 +45,6 @@ func initCommand() *cli.Command {
 		Name:  "init",
 		Usage: "Initialize Kubernetes cluster",
 		Flags: []cli.Flag{
-			&cli.StringFlag{
-				Name:    "config",
-				Aliases: []string{"c"},
-				Usage:   "Path to configuration file",
-				Sources: cli.EnvVars("FOUNDRY_CONFIG"),
-			},
 			&cli.BoolFlag{
 				Name:  "single-node",
 				Usage: "Initialize single-node cluster (overrides config)",
@@ -65,10 +59,10 @@ func initCommand() *cli.Command {
 }
 
 func runClusterInit(ctx context.Context, cmd *cli.Command) error {
-	// Load configuration
-	configPath := cmd.String("config")
-	if configPath == "" {
-		configPath = config.DefaultConfigPath()
+	// Load configuration (--config flag inherited from root command)
+	configPath, err := config.FindConfig(cmd.String("config"))
+	if err != nil {
+		return fmt.Errorf("failed to find config: %w", err)
 	}
 
 	cfg, err := config.Load(configPath)

--- a/v1/cmd/foundry/commands/cluster/init_test.go
+++ b/v1/cmd/foundry/commands/cluster/init_test.go
@@ -21,14 +21,12 @@ func TestInitCommand(t *testing.T) {
 	assert.Equal(t, "Initialize Kubernetes cluster", cmd.Usage)
 	assert.NotNil(t, cmd.Action)
 
-	// Check flags
-	assert.Len(t, cmd.Flags, 3)
+	// Check flags (--config is inherited from root command, not defined here)
+	assert.Len(t, cmd.Flags, 2)
 
-	var hasConfigFlag, hasSingleNodeFlag, hasDryRunFlag bool
+	var hasSingleNodeFlag, hasDryRunFlag bool
 	for _, flag := range cmd.Flags {
 		switch flag.Names()[0] {
-		case "config":
-			hasConfigFlag = true
 		case "single-node":
 			hasSingleNodeFlag = true
 		case "dry-run":
@@ -36,7 +34,6 @@ func TestInitCommand(t *testing.T) {
 		}
 	}
 
-	assert.True(t, hasConfigFlag, "should have config flag")
 	assert.True(t, hasSingleNodeFlag, "should have single-node flag")
 	assert.True(t, hasDryRunFlag, "should have dry-run flag")
 }
@@ -123,9 +120,16 @@ func TestRunClusterInit_MissingConfig(t *testing.T) {
 	tmpDir := t.TempDir()
 	nonExistentConfig := filepath.Join(tmpDir, "nonexistent.yaml")
 
-	// Create CLI app with cluster commands
+	// Create CLI app with cluster commands (--config flag on root, inherited by subcommands)
 	app := &cli.Command{
 		Name: "foundry",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:    "config",
+				Aliases: []string{"c"},
+				Usage:   "path to config file",
+			},
+		},
 		Commands: []*cli.Command{
 			Commands(),
 		},
@@ -139,7 +143,7 @@ func TestRunClusterInit_MissingConfig(t *testing.T) {
 
 	// We expect an error since the config doesn't exist
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to load config")
+	assert.Contains(t, err.Error(), "failed to find config")
 }
 
 func TestRunClusterInit_DryRun(t *testing.T) {
@@ -173,9 +177,16 @@ func TestRunClusterInit_DryRun(t *testing.T) {
 	err := config.Save(testConfig, configPath)
 	require.NoError(t, err)
 
-	// Create CLI app
+	// Create CLI app (--config flag on root, inherited by subcommands)
 	app := &cli.Command{
 		Name: "foundry",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:    "config",
+				Aliases: []string{"c"},
+				Usage:   "path to config file",
+			},
+		},
 		Commands: []*cli.Command{
 			Commands(),
 		},
@@ -209,9 +220,16 @@ func TestRunClusterInit_NoClusterConfig(t *testing.T) {
 	err := config.Save(testConfig, configPath)
 	require.NoError(t, err)
 
-	// Create CLI app
+	// Create CLI app (--config flag on root, inherited by subcommands)
 	app := &cli.Command{
 		Name: "foundry",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:    "config",
+				Aliases: []string{"c"},
+				Usage:   "path to config file",
+			},
+		},
 		Commands: []*cli.Command{
 			Commands(),
 		},
@@ -249,9 +267,16 @@ func TestRunClusterInit_NoNodes(t *testing.T) {
 	err := config.Save(testConfig, configPath)
 	require.NoError(t, err)
 
-	// Create CLI app
+	// Create CLI app (--config flag on root, inherited by subcommands)
 	app := &cli.Command{
 		Name: "foundry",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:    "config",
+				Aliases: []string{"c"},
+				Usage:   "path to config file",
+			},
+		},
 		Commands: []*cli.Command{
 			Commands(),
 		},
@@ -297,9 +322,16 @@ func TestRunClusterInit_SingleNodeFlag(t *testing.T) {
 	err := config.Save(testConfig, configPath)
 	require.NoError(t, err)
 
-	// Create CLI app
+	// Create CLI app (--config flag on root, inherited by subcommands)
 	app := &cli.Command{
 		Name: "foundry",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:    "config",
+				Aliases: []string{"c"},
+				Usage:   "path to config file",
+			},
+		},
 		Commands: []*cli.Command{
 			Commands(),
 		},

--- a/v1/cmd/foundry/commands/cluster/node_add.go
+++ b/v1/cmd/foundry/commands/cluster/node_add.go
@@ -30,12 +30,6 @@ func NewNodeAddCommand() *cli.Command {
 				Name:  "role",
 				Usage: "Node role: control-plane, worker, or both (default: auto)",
 			},
-			&cli.StringFlag{
-				Name:    "config",
-				Aliases: []string{"c"},
-				Usage:   "Path to configuration file",
-				Sources: cli.EnvVars("FOUNDRY_CONFIG"),
-			},
 			&cli.BoolFlag{
 				Name:  "dry-run",
 				Usage: "Show what would be done without making changes",
@@ -56,10 +50,10 @@ func runNodeAdd(ctx context.Context, cmd *cli.Command) error {
 	}
 	hostname := cmd.Args().Get(0)
 
-	// Load configuration
-	configPath := cmd.String("config")
-	if configPath == "" {
-		configPath = config.DefaultConfigPath()
+	// Load configuration (--config flag inherited from root command)
+	configPath, err := config.FindConfig(cmd.String("config"))
+	if err != nil {
+		return fmt.Errorf("failed to find config: %w", err)
 	}
 
 	cfg, err := config.Load(configPath)

--- a/v1/cmd/foundry/commands/cluster/node_add_test.go
+++ b/v1/cmd/foundry/commands/cluster/node_add_test.go
@@ -28,8 +28,8 @@ func TestNewNodeAddCommand(t *testing.T) {
 		}
 	}
 	assert.True(t, flagNames["role"])
-	assert.True(t, flagNames["config"])
 	assert.True(t, flagNames["dry-run"])
+	// --config is now inherited from root command, not defined on subcommand
 }
 
 func TestNodeAddCommand_DryRun(t *testing.T) {
@@ -66,9 +66,16 @@ func TestNodeAddCommand_DryRun(t *testing.T) {
 	err = config.Save(testConfig, configPath)
 	require.NoError(t, err)
 
-	// Create CLI app
+	// Create CLI app (--config flag on root, inherited by subcommands)
 	app := &cli.Command{
 		Name: "foundry",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:    "config",
+				Aliases: []string{"c"},
+				Usage:   "path to config file",
+			},
+		},
 		Commands: []*cli.Command{
 			Commands(),
 		},
@@ -104,8 +111,16 @@ func TestNodeAddCommand_MissingHostname(t *testing.T) {
 	err := config.Save(testConfig, configPath)
 	require.NoError(t, err)
 
+	// Create CLI app (--config flag on root, inherited by subcommands)
 	app := &cli.Command{
 		Name: "foundry",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:    "config",
+				Aliases: []string{"c"},
+				Usage:   "path to config file",
+			},
+		},
 		Commands: []*cli.Command{
 			Commands(),
 		},
@@ -145,8 +160,16 @@ func TestNodeAddCommand_HostNotFound(t *testing.T) {
 	err := config.Save(testConfig, configPath)
 	require.NoError(t, err)
 
+	// Create CLI app (--config flag on root, inherited by subcommands)
 	app := &cli.Command{
 		Name: "foundry",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:    "config",
+				Aliases: []string{"c"},
+				Usage:   "path to config file",
+			},
+		},
 		Commands: []*cli.Command{
 			Commands(),
 		},

--- a/v1/cmd/foundry/commands/cluster/node_remove.go
+++ b/v1/cmd/foundry/commands/cluster/node_remove.go
@@ -20,12 +20,6 @@ func NewNodeRemoveCommand() *cli.Command {
 		Usage:     "Remove a node from the K3s cluster",
 		ArgsUsage: "<hostname>",
 		Flags: []cli.Flag{
-			&cli.StringFlag{
-				Name:    "config",
-				Aliases: []string{"c"},
-				Usage:   "Path to configuration file",
-				Sources: cli.EnvVars("FOUNDRY_CONFIG"),
-			},
 			&cli.BoolFlag{
 				Name:  "dry-run",
 				Usage: "Show what would be done without making changes",
@@ -46,10 +40,10 @@ func runNodeRemove(ctx context.Context, cmd *cli.Command) error {
 	}
 	hostname := cmd.Args().Get(0)
 
-	// Load configuration
-	configPath := cmd.String("config")
-	if configPath == "" {
-		configPath = config.DefaultConfigPath()
+	// Load configuration (--config flag inherited from root command)
+	configPath, err := config.FindConfig(cmd.String("config"))
+	if err != nil {
+		return fmt.Errorf("failed to find config: %w", err)
 	}
 
 	cfg, err := config.Load(configPath)

--- a/v1/cmd/foundry/commands/cluster/node_remove_test.go
+++ b/v1/cmd/foundry/commands/cluster/node_remove_test.go
@@ -27,9 +27,9 @@ func TestNewNodeRemoveCommand(t *testing.T) {
 			flagNames[name] = true
 		}
 	}
-	assert.True(t, flagNames["config"])
 	assert.True(t, flagNames["dry-run"])
 	assert.True(t, flagNames["force"])
+	// --config is now inherited from root command, not defined on subcommand
 }
 
 func TestNodeRemoveCommand_DryRun(t *testing.T) {
@@ -66,9 +66,16 @@ func TestNodeRemoveCommand_DryRun(t *testing.T) {
 	err = config.Save(testConfig, configPath)
 	require.NoError(t, err)
 
-	// Create CLI app
+	// Create CLI app (--config flag on root, inherited by subcommands)
 	app := &cli.Command{
 		Name: "foundry",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:    "config",
+				Aliases: []string{"c"},
+				Usage:   "path to config file",
+			},
+		},
 		Commands: []*cli.Command{
 			Commands(),
 		},
@@ -104,8 +111,16 @@ func TestNodeRemoveCommand_MissingHostname(t *testing.T) {
 	err := config.Save(testConfig, configPath)
 	require.NoError(t, err)
 
+	// Create CLI app (--config flag on root, inherited by subcommands)
 	app := &cli.Command{
 		Name: "foundry",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:    "config",
+				Aliases: []string{"c"},
+				Usage:   "path to config file",
+			},
+		},
 		Commands: []*cli.Command{
 			Commands(),
 		},
@@ -144,8 +159,16 @@ func TestNodeRemoveCommand_HostNotFound(t *testing.T) {
 	err := config.Save(testConfig, configPath)
 	require.NoError(t, err)
 
+	// Create CLI app (--config flag on root, inherited by subcommands)
 	app := &cli.Command{
 		Name: "foundry",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:    "config",
+				Aliases: []string{"c"},
+				Usage:   "path to config file",
+			},
+		},
 		Commands: []*cli.Command{
 			Commands(),
 		},

--- a/v1/cmd/foundry/commands/dns/record.go
+++ b/v1/cmd/foundry/commands/dns/record.go
@@ -47,13 +47,6 @@ Examples:
   foundry dns record add example.com. @ TXT "v=spf1 mx ~all"
   foundry dns record add example.com. www.example.com. A 192.168.1.10 --ttl 7200`,
 	Flags: []cli.Flag{
-		&cli.StringFlag{
-			Name:    "config",
-			Aliases: []string{"c"},
-			Usage:   "Path to configuration file",
-			Value:   config.DefaultConfigPath(),
-			Sources: cli.EnvVars("FOUNDRY_CONFIG"),
-		},
 		&cli.IntFlag{
 			Name:  "ttl",
 			Usage: "Time to live in seconds",
@@ -75,13 +68,6 @@ Example:
   foundry dns record list example.com.`,
 	Flags: []cli.Flag{
 		&cli.StringFlag{
-			Name:    "config",
-			Aliases: []string{"c"},
-			Usage:   "Path to configuration file",
-			Value:   config.DefaultConfigPath(),
-			Sources: cli.EnvVars("FOUNDRY_CONFIG"),
-		},
-		&cli.StringFlag{
 			Name:  "type",
 			Usage: "Filter by record type (A, AAAA, CNAME, etc.)",
 		},
@@ -101,13 +87,6 @@ Examples:
   foundry dns record delete example.com. www.example.com. A
   foundry dns record delete example.com. mail.example.com. MX`,
 	Flags: []cli.Flag{
-		&cli.StringFlag{
-			Name:    "config",
-			Aliases: []string{"c"},
-			Usage:   "Path to configuration file",
-			Value:   config.DefaultConfigPath(),
-			Sources: cli.EnvVars("FOUNDRY_CONFIG"),
-		},
 		&cli.BoolFlag{
 			Name:  "yes",
 			Usage: "Skip confirmation prompt",
@@ -126,7 +105,6 @@ func runRecordAdd(ctx context.Context, cmd *cli.Command) error {
 	recordName := cmd.Args().Get(1)
 	recordType := strings.ToUpper(cmd.Args().Get(2))
 	recordContent := cmd.Args().Get(3)
-	configPath := cmd.String("config")
 	ttl := cmd.Int("ttl")
 
 	// Ensure zone name ends with dot
@@ -147,7 +125,12 @@ func runRecordAdd(ctx context.Context, cmd *cli.Command) error {
 		}
 	}
 
-	// Load configuration
+	// Load configuration (--config flag inherited from root command)
+	configPath, err := config.FindConfig(cmd.String("config"))
+	if err != nil {
+		return fmt.Errorf("failed to find config: %w", err)
+	}
+
 	cfg, err := config.Load(configPath)
 	if err != nil {
 		return fmt.Errorf("failed to load config: %w", err)
@@ -218,7 +201,12 @@ func runRecordList(ctx context.Context, cmd *cli.Command) error {
 		zoneName = zoneName + "."
 	}
 
-	// Load configuration
+	// Load configuration (--config flag inherited from root command)
+	configPath, err := config.FindConfig(cmd.String("config"))
+	if err != nil {
+		return fmt.Errorf("failed to find config: %w", err)
+	}
+
 	cfg, err := config.Load(configPath)
 	if err != nil {
 		return fmt.Errorf("failed to load config: %w", err)
@@ -334,7 +322,12 @@ func runRecordDelete(ctx context.Context, cmd *cli.Command) error {
 		}
 	}
 
-	// Load configuration
+	// Load configuration (--config flag inherited from root command)
+	configPath, err := config.FindConfig(cmd.String("config"))
+	if err != nil {
+		return fmt.Errorf("failed to find config: %w", err)
+	}
+
 	cfg, err := config.Load(configPath)
 	if err != nil {
 		return fmt.Errorf("failed to load config: %w", err)

--- a/v1/cmd/foundry/commands/host/add.go
+++ b/v1/cmd/foundry/commands/host/add.go
@@ -55,8 +55,8 @@ var AddCommand = &cli.Command{
 }
 
 func runAdd(ctx context.Context, cmd *cli.Command) error {
-	// Initialize config-based host registry
-	configPath, err := config.FindConfig("")
+	// Initialize config-based host registry (--config flag inherited from root command)
+	configPath, err := config.FindConfig(cmd.String("config"))
 	if err != nil {
 		return fmt.Errorf("failed to find config file: %w (run 'foundry config init' first)", err)
 	}

--- a/v1/cmd/foundry/commands/host/configure.go
+++ b/v1/cmd/foundry/commands/host/configure.go
@@ -19,12 +19,6 @@ var ConfigureCommand = &cli.Command{
 	Usage:     "Run basic configuration on a host",
 	ArgsUsage: "<hostname>",
 	Flags: []cli.Flag{
-		&cli.StringFlag{
-			Name:    "config",
-			Aliases: []string{"c"},
-			Usage:   "Path to configuration file",
-			Sources: cli.EnvVars("FOUNDRY_CONFIG"),
-		},
 		&cli.BoolFlag{
 			Name:  "skip-update",
 			Usage: "skip package updates",
@@ -54,14 +48,10 @@ func runConfigure(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("host not found: %w", err)
 	}
 
-	// Load config to get cluster name
-	configPath := cmd.String("config")
-	if configPath == "" {
-		var err error
-		configPath, err = config.FindConfig("")
-		if err != nil {
-			return fmt.Errorf("failed to find config: %w", err)
-		}
+	// Load config to get cluster name (--config flag inherited from root command)
+	configPath, err := config.FindConfig(cmd.String("config"))
+	if err != nil {
+		return fmt.Errorf("failed to find config: %w", err)
 	}
 	cfg, err := config.Load(configPath)
 	if err != nil {

--- a/v1/cmd/foundry/commands/host/configure_test.go
+++ b/v1/cmd/foundry/commands/host/configure_test.go
@@ -84,9 +84,16 @@ func TestRunConfigure_NoSSHKey(t *testing.T) {
 	err = host.Add(h)
 	require.NoError(t, err)
 
-	// Create a test command
+	// Create a test command (--config flag on root, inherited by subcommands)
 	app := &cli.Command{
 		Name: "test",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:    "config",
+				Aliases: []string{"c"},
+				Usage:   "path to config file",
+			},
+		},
 		Commands: []*cli.Command{
 			ConfigureCommand,
 		},

--- a/v1/cmd/foundry/commands/host/list.go
+++ b/v1/cmd/foundry/commands/host/list.go
@@ -26,8 +26,8 @@ var ListCommand = &cli.Command{
 }
 
 func runList(ctx context.Context, cmd *cli.Command) error {
-	// Initialize config-based host registry
-	configPath, err := config.FindConfig("")
+	// Initialize config-based host registry (--config flag inherited from root command)
+	configPath, err := config.FindConfig(cmd.String("config"))
 	if err != nil {
 		return fmt.Errorf("failed to find config file: %w (run 'foundry config init' first)", err)
 	}

--- a/v1/cmd/foundry/commands/host/migrate_keys.go
+++ b/v1/cmd/foundry/commands/host/migrate_keys.go
@@ -39,8 +39,8 @@ OpenBAO must be installed and initialized before running this command.`,
 }
 
 func runMigrateKeys(ctx context.Context, cmd *cli.Command) error {
-	// Find config file
-	configPath, err := config.FindConfig("")
+	// Find config file (--config flag inherited from root command)
+	configPath, err := config.FindConfig(cmd.String("config"))
 	if err != nil {
 		return fmt.Errorf("failed to find config file: %w (run 'foundry config init' first)", err)
 	}

--- a/v1/cmd/foundry/commands/network/plan.go
+++ b/v1/cmd/foundry/commands/network/plan.go
@@ -32,20 +32,16 @@ After completing the wizard:
   2. Assign roles to hosts (openbao, dns, zot, cluster-control-plane, cluster-worker)
   3. Configure static IPs or DHCP reservations for your infrastructure hosts
   4. Use 'foundry network validate' to verify the configuration`,
-	Flags: []cli.Flag{
-		&cli.StringFlag{
-			Name:    "config",
-			Aliases: []string{"c"},
-			Usage:   "Path to configuration file",
-			Value:   config.DefaultConfigPath(),
-			Sources: cli.EnvVars("FOUNDRY_CONFIG"),
-		},
-	},
 	Action: runPlan,
 }
 
 func runPlan(ctx context.Context, cmd *cli.Command) error {
-	configPath := cmd.String("config")
+	// Get config path (--config flag inherited from root command)
+	configPath, err := config.FindConfig(cmd.String("config"))
+	if err != nil {
+		// For plan, missing config is OK - use default path
+		configPath = config.DefaultConfigPath()
+	}
 
 	// Load existing config or create new one
 	cfg, err := config.Load(configPath)

--- a/v1/cmd/foundry/commands/network/validate.go
+++ b/v1/cmd/foundry/commands/network/validate.go
@@ -32,13 +32,6 @@ Requirements:
   - Network configuration must be present in config file
   - SSH access to at least one host (for reachability checks)`,
 	Flags: []cli.Flag{
-		&cli.StringFlag{
-			Name:    "config",
-			Aliases: []string{"c"},
-			Usage:   "Path to configuration file",
-			Value:   config.DefaultConfigPath(),
-			Sources: cli.EnvVars("FOUNDRY_CONFIG"),
-		},
 		&cli.BoolFlag{
 			Name:  "skip-reachability",
 			Usage: "Skip reachability checks (ping tests)",
@@ -54,11 +47,15 @@ Requirements:
 }
 
 func runValidate(ctx context.Context, cmd *cli.Command) error {
-	configPath := cmd.String("config")
 	skipReachability := cmd.Bool("skip-reachability")
 	skipDNS := cmd.Bool("skip-dns")
 
-	// Load configuration
+	// Load configuration (--config flag inherited from root command)
+	configPath, err := config.FindConfig(cmd.String("config"))
+	if err != nil {
+		return fmt.Errorf("failed to find config: %w", err)
+	}
+
 	cfg, err := config.Load(configPath)
 	if err != nil {
 		return fmt.Errorf("failed to load config: %w", err)

--- a/v1/cmd/foundry/commands/stack/install.go
+++ b/v1/cmd/foundry/commands/stack/install.go
@@ -108,12 +108,6 @@ Examples:
   # Resume after interruption
   foundry stack install  # Automatically picks up where it left off`,
 	Flags: []cli.Flag{
-		&cli.StringFlag{
-			Name:    "config",
-			Aliases: []string{"c"},
-			Usage:   "Path to configuration file",
-			Sources: cli.EnvVars("FOUNDRY_CONFIG"),
-		},
 		// Config initialization flags
 		&cli.StringFlag{
 			Name:  "cluster-name",
@@ -182,9 +176,10 @@ func NewStackInstaller(registry *component.Registry, installer ComponentInstalle
 }
 
 func runStackInstall(ctx context.Context, cmd *cli.Command) error {
-	// Determine config path
-	configPath := cmd.String("config")
-	if configPath == "" {
+	// Determine config path (--config flag inherited from root command)
+	configPath, err := config.FindConfig(cmd.String("config"))
+	if err != nil {
+		// For install, missing config is OK - we'll create one
 		configPath = config.DefaultConfigPath()
 	}
 

--- a/v1/cmd/foundry/commands/stack/status.go
+++ b/v1/cmd/foundry/commands/stack/status.go
@@ -12,27 +12,19 @@ import (
 
 // StatusCommand handles the 'foundry stack status' command
 var StatusCommand = &cli.Command{
-	Name:  "status",
-	Usage: "Show status of all stack components",
-	Flags: []cli.Flag{
-		&cli.StringFlag{
-			Name:    "config",
-			Aliases: []string{"c"},
-			Usage:   "Path to configuration file",
-			Sources: cli.EnvVars("FOUNDRY_CONFIG"),
-		},
-	},
+	Name:   "status",
+	Usage:  "Show status of all stack components",
 	Action: runStackStatus,
 }
 
 func runStackStatus(ctx context.Context, cmd *cli.Command) error {
-	// Load configuration
-	configPath := cmd.String("config")
-	if configPath == "" {
-		configPath = config.DefaultConfigPath()
+	// Load configuration (--config flag inherited from root command)
+	configPath, err := config.FindConfig(cmd.String("config"))
+	if err != nil {
+		return fmt.Errorf("failed to find config: %w", err)
 	}
 
-	_, err := config.Load(configPath)
+	_, err = config.Load(configPath)
 	if err != nil {
 		return fmt.Errorf("failed to load config: %w", err)
 	}

--- a/v1/cmd/foundry/commands/stack/validate.go
+++ b/v1/cmd/foundry/commands/stack/validate.go
@@ -12,24 +12,16 @@ import (
 
 // ValidateCommand handles the 'foundry stack validate' command
 var ValidateCommand = &cli.Command{
-	Name:  "validate",
-	Usage: "Validate stack configuration without installing",
-	Flags: []cli.Flag{
-		&cli.StringFlag{
-			Name:    "config",
-			Aliases: []string{"c"},
-			Usage:   "Path to configuration file",
-			Sources: cli.EnvVars("FOUNDRY_CONFIG"),
-		},
-	},
+	Name:   "validate",
+	Usage:  "Validate stack configuration without installing",
 	Action: runStackValidate,
 }
 
 func runStackValidate(ctx context.Context, cmd *cli.Command) error {
-	// Load configuration
-	configPath := cmd.String("config")
-	if configPath == "" {
-		configPath = config.DefaultConfigPath()
+	// Load configuration (--config flag inherited from root command)
+	configPath, err := config.FindConfig(cmd.String("config"))
+	if err != nil {
+		return fmt.Errorf("failed to find config: %w", err)
 	}
 
 	cfg, err := config.Load(configPath)

--- a/v1/cmd/foundry/commands/storage/add_disk.go
+++ b/v1/cmd/foundry/commands/storage/add_disk.go
@@ -60,12 +60,6 @@ Examples:
 			Aliases: []string{"y"},
 			Usage:   "Skip confirmation prompts",
 		},
-		&cli.StringFlag{
-			Name:    "config",
-			Aliases: []string{"c"},
-			Usage:   "Path to configuration file",
-			Sources: cli.EnvVars("FOUNDRY_CONFIG"),
-		},
 	},
 	Action: runAddDisk,
 }
@@ -87,10 +81,10 @@ type LonghornDiskConfig struct {
 }
 
 func runAddDisk(ctx context.Context, cmd *cli.Command) error {
-	// Load configuration
-	configPath := cmd.String("config")
-	if configPath == "" {
-		configPath = config.DefaultConfigPath()
+	// Load configuration (--config flag inherited from root command)
+	configPath, err := config.FindConfig(cmd.String("config"))
+	if err != nil {
+		return fmt.Errorf("failed to find config: %w", err)
 	}
 
 	cfg, err := config.Load(configPath)

--- a/v1/cmd/foundry/commands/storage/add_disk_test.go
+++ b/v1/cmd/foundry/commands/storage/add_disk_test.go
@@ -487,5 +487,5 @@ func TestAddDiskCommand_Structure(t *testing.T) {
 	assert.Contains(t, flagNames, "dry-run")
 	assert.Contains(t, flagNames, "yes")
 	assert.Contains(t, flagNames, "y") // yes alias
-	assert.Contains(t, flagNames, "config")
+	// --config is now inherited from root command, not defined on subcommand
 }

--- a/v1/cmd/foundry/commands/storage/commands_test.go
+++ b/v1/cmd/foundry/commands/storage/commands_test.go
@@ -36,15 +36,5 @@ func TestListCommand(t *testing.T) {
 	assert.NotNil(t, ListCommand, "ListCommand should not be nil")
 	assert.Equal(t, "list", ListCommand.Name)
 	assert.NotNil(t, ListCommand.Action, "ListCommand should have an action")
-
-	// Check flags
-	var foundConfig bool
-	for _, flag := range ListCommand.Flags {
-		switch flag.Names()[0] {
-		case "config":
-			foundConfig = true
-		}
-	}
-
-	assert.True(t, foundConfig, "Should have --config flag")
+	// --config is now inherited from root command, not defined on subcommand
 }

--- a/v1/cmd/foundry/commands/storage/list.go
+++ b/v1/cmd/foundry/commands/storage/list.go
@@ -17,22 +17,14 @@ var ListCommand = &cli.Command{
 This command displays:
   - Storage backend type (local-path, nfs, longhorn)
   - Configuration status`,
-	Flags: []cli.Flag{
-		&cli.StringFlag{
-			Name:    "config",
-			Aliases: []string{"c"},
-			Usage:   "Path to config file",
-			Sources: cli.EnvVars("FOUNDRY_CONFIG"),
-		},
-	},
 	Action: runList,
 }
 
 func runList(ctx context.Context, cmd *cli.Command) error {
-	// Load config
-	configPath := cmd.String("config")
-	if configPath == "" {
-		configPath = config.DefaultConfigPath()
+	// Load config (--config flag inherited from root command)
+	configPath, err := config.FindConfig(cmd.String("config"))
+	if err != nil {
+		return fmt.Errorf("failed to find config: %w", err)
 	}
 
 	cfg, err := config.Load(configPath)


### PR DESCRIPTION
This makes the config flag `--config` for specifying a config file respect the env var and also universally part of the root command. Previously it would only use the default in most cases, which was ~/.foundry/stack.yaml and that was not what I am doing with a production environment