### PR TITLE
fix: adjust config file and install for dns success

### DIFF
--- a/csil/v1/config/network-simple.csil
+++ b/csil/v1/config/network-simple.csil
@@ -43,10 +43,12 @@ DNSZone = {
 }
 
 ; Cluster configuration for K3s
+; Note: primary_domain is the preferred field; domain is deprecated but still supported for backwards compatibility
 ClusterConfig = {
     name: text,
-    domain: text,
-    vip: text @go_name("VIP")  ; Kubernetes VIP (Virtual IP for cluster API access)
+    ? domain: text,
+    primary_domain: text @go_name("PrimaryDomain"),
+    vip: text @go_name("VIP")
 }
 
 ; Map of component names to their configurations

--- a/v1/cmd/foundry/commands/cluster/init.go
+++ b/v1/cmd/foundry/commands/cluster/init.go
@@ -119,7 +119,7 @@ func runClusterInit(ctx context.Context, cmd *cli.Command) error {
 func printClusterPlan(cfg *config.Config) error {
 	fmt.Println("\nCluster initialization plan:")
 	fmt.Printf("  Cluster name: %s\n", cfg.Cluster.Name)
-	fmt.Printf("  Domain: %s\n", cfg.Cluster.Domain)
+	fmt.Printf("  Domain: %s\n", cfg.Cluster.PrimaryDomain)
 	fmt.Printf("  VIP: %s\n", cfg.Cluster.VIP)
 	fmt.Println("\nHosts:")
 
@@ -281,7 +281,7 @@ func InitializeCluster(ctx context.Context, cfg *config.Config) error {
 		VIP:          cfg.Cluster.VIP,
 		TLSSANs: []string{
 			cfg.Cluster.VIP,
-			fmt.Sprintf("%s.%s", cfg.Cluster.Name, cfg.Cluster.Domain),
+			fmt.Sprintf("%s.%s", cfg.Cluster.Name, cfg.Cluster.PrimaryDomain),
 		},
 		DisableComponents: []string{"traefik", "servicelb"},
 	}

--- a/v1/cmd/foundry/commands/cluster/init_test.go
+++ b/v1/cmd/foundry/commands/cluster/init_test.go
@@ -47,9 +47,9 @@ func TestPrintClusterPlan(t *testing.T) {
 			name: "single node cluster",
 			config: &config.Config{
 				Cluster: config.ClusterConfig{
-					Name:   "test-cluster",
-					Domain: "example.com",
-					VIP:    "192.168.1.100",
+					Name:          "test-cluster",
+					PrimaryDomain: "example.com",
+					VIP:           "192.168.1.100",
 				},
 				Network: &config.NetworkConfig{
 				},
@@ -66,9 +66,9 @@ func TestPrintClusterPlan(t *testing.T) {
 			name: "multi-node cluster",
 			config: &config.Config{
 				Cluster: config.ClusterConfig{
-					Name:   "prod-cluster",
-					Domain: "example.com",
-					VIP:    "192.168.1.100",
+					Name:          "prod-cluster",
+					PrimaryDomain: "example.com",
+					VIP:           "192.168.1.100",
 				},
 				Network: &config.NetworkConfig{
 				},
@@ -90,9 +90,9 @@ func TestPrintClusterPlan(t *testing.T) {
 			name: "cluster with explicit roles",
 			config: &config.Config{
 				Cluster: config.ClusterConfig{
-					Name:   "test-cluster",
-					Domain: "example.com",
-					VIP:    "192.168.1.100",
+					Name:          "test-cluster",
+					PrimaryDomain: "example.com",
+					VIP:           "192.168.1.100",
 				},
 				Network: &config.NetworkConfig{
 				},
@@ -153,9 +153,9 @@ func TestRunClusterInit_DryRun(t *testing.T) {
 
 	testConfig := &config.Config{
 		Cluster: config.ClusterConfig{
-			Name:   "test-cluster",
-			Domain: "example.com",
-			VIP:    "192.168.1.100",
+			Name:          "test-cluster",
+			PrimaryDomain: "example.com",
+			VIP:           "192.168.1.100",
 		},
 		Network: &config.NetworkConfig{
 			Gateway: "192.168.1.1",
@@ -252,8 +252,8 @@ func TestRunClusterInit_NoNodes(t *testing.T) {
 
 	testConfig := &config.Config{
 		Cluster: config.ClusterConfig{
-			Name:   "test-cluster",
-			Domain: "example.com",
+			Name:          "test-cluster",
+			PrimaryDomain: "example.com",
 		},
 		Network: &config.NetworkConfig{
 			Gateway:      "192.168.1.1",
@@ -299,9 +299,9 @@ func TestRunClusterInit_SingleNodeFlag(t *testing.T) {
 
 	testConfig := &config.Config{
 		Cluster: config.ClusterConfig{
-			Name:   "test-cluster",
-			Domain: "example.com",
-			VIP:    "192.168.1.100",
+			Name:          "test-cluster",
+			PrimaryDomain: "example.com",
+			VIP:           "192.168.1.100",
 		},
 		Network: &config.NetworkConfig{
 			Gateway: "192.168.1.1",
@@ -353,9 +353,9 @@ func TestInitializeCluster_HostNotFound(t *testing.T) {
 
 	cfg := &config.Config{
 		Cluster: config.ClusterConfig{
-			Name:   "test-cluster",
-			Domain: "example.com",
-			},
+			Name:          "test-cluster",
+			PrimaryDomain: "example.com",
+		},
 		Network: &config.NetworkConfig{
 			Gateway:      "192.168.1.1",
 			Netmask:      "255.255.255.0",

--- a/v1/cmd/foundry/commands/cluster/node_add.go
+++ b/v1/cmd/foundry/commands/cluster/node_add.go
@@ -266,7 +266,7 @@ func addNodeToCluster(ctx context.Context, hostname string, nodeRole *k3s.Determ
 		VIP:          cfg.Cluster.VIP,
 		TLSSANs: []string{
 			cfg.Cluster.VIP,
-			fmt.Sprintf("%s.%s", cfg.Cluster.Name, cfg.Cluster.Domain),
+			fmt.Sprintf("%s.%s", cfg.Cluster.Name, cfg.Cluster.PrimaryDomain),
 		},
 		DisableComponents: []string{"traefik", "servicelb"},
 	}

--- a/v1/cmd/foundry/commands/cluster/node_add_test.go
+++ b/v1/cmd/foundry/commands/cluster/node_add_test.go
@@ -50,9 +50,9 @@ func TestNodeAddCommand_DryRun(t *testing.T) {
 
 	testConfig := &config.Config{
 		Cluster: config.ClusterConfig{
-			Name:   "test-cluster",
-			Domain: "example.com",
-			VIP:    "192.168.1.100",
+			Name:          "test-cluster",
+			PrimaryDomain: "example.com",
+			VIP:           "192.168.1.100",
 		},
 		Network: &config.NetworkConfig{
 			Gateway: "192.168.1.1",
@@ -144,9 +144,9 @@ func TestNodeAddCommand_HostNotFound(t *testing.T) {
 
 	testConfig := &config.Config{
 		Cluster: config.ClusterConfig{
-			Name:   "test",
-			Domain: "example.com",
-			VIP:    "192.168.1.100",
+			Name:          "test",
+			PrimaryDomain: "example.com",
+			VIP:           "192.168.1.100",
 		},
 		Network: &config.NetworkConfig{
 			Gateway: "192.168.1.1",
@@ -187,8 +187,8 @@ func TestNodeAddCommand_HostNotFound(t *testing.T) {
 func TestDetermineNodeRole_ExplicitControlPlane(t *testing.T) {
 	cfg := &config.Config{
 		Cluster: config.ClusterConfig{
-			Name:   "test-cluster",
-			Domain: "example.com",
+			Name:          "test-cluster",
+			PrimaryDomain: "example.com",
 		},
 		Hosts: []*host.Host{
 			{
@@ -207,8 +207,8 @@ func TestDetermineNodeRole_ExplicitControlPlane(t *testing.T) {
 func TestDetermineNodeRole_ExplicitWorker(t *testing.T) {
 	cfg := &config.Config{
 		Cluster: config.ClusterConfig{
-			Name:   "test-cluster",
-			Domain: "example.com",
+			Name:          "test-cluster",
+			PrimaryDomain: "example.com",
 		},
 		Hosts: []*host.Host{
 			{
@@ -227,8 +227,8 @@ func TestDetermineNodeRole_ExplicitWorker(t *testing.T) {
 func TestDetermineNodeRole_ExplicitBoth(t *testing.T) {
 	cfg := &config.Config{
 		Cluster: config.ClusterConfig{
-			Name:   "test-cluster",
-			Domain: "example.com",
+			Name:          "test-cluster",
+			PrimaryDomain: "example.com",
 		},
 		Hosts: []*host.Host{
 			{
@@ -247,8 +247,8 @@ func TestDetermineNodeRole_ExplicitBoth(t *testing.T) {
 func TestDetermineNodeRole_InvalidRole(t *testing.T) {
 	cfg := &config.Config{
 		Cluster: config.ClusterConfig{
-			Name:   "test-cluster",
-			Domain: "example.com",
+			Name:          "test-cluster",
+			PrimaryDomain: "example.com",
 		},
 		Hosts: []*host.Host{
 			{
@@ -332,8 +332,8 @@ func TestDetermineNodeRole_AutoLessThan3ControlPlanes(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := &config.Config{
 				Cluster: config.ClusterConfig{
-					Name:   "test-cluster",
-					Domain: "example.com",
+					Name:          "test-cluster",
+					PrimaryDomain: "example.com",
 				},
 				Hosts: tt.existingHosts,
 			}
@@ -350,8 +350,8 @@ func TestDetermineNodeRole_AutoCountsControlPlaneRole(t *testing.T) {
 	// Hosts with cluster-control-plane role should count toward control plane count
 	cfg := &config.Config{
 		Cluster: config.ClusterConfig{
-			Name:   "test-cluster",
-			Domain: "example.com",
+			Name:          "test-cluster",
+			PrimaryDomain: "example.com",
 		},
 		Hosts: []*host.Host{
 			{

--- a/v1/cmd/foundry/commands/cluster/node_remove_test.go
+++ b/v1/cmd/foundry/commands/cluster/node_remove_test.go
@@ -50,9 +50,9 @@ func TestNodeRemoveCommand_DryRun(t *testing.T) {
 
 	testConfig := &config.Config{
 		Cluster: config.ClusterConfig{
-			Name:   "test-cluster",
-			Domain: "example.com",
-			VIP:    "192.168.1.100",
+			Name:          "test-cluster",
+			PrimaryDomain: "example.com",
+			VIP:           "192.168.1.100",
 		},
 		Network: &config.NetworkConfig{
 			Gateway: "192.168.1.1",
@@ -143,9 +143,9 @@ func TestNodeRemoveCommand_HostNotFound(t *testing.T) {
 
 	testConfig := &config.Config{
 		Cluster: config.ClusterConfig{
-			Name:   "test",
-			Domain: "example.com",
-			VIP:    "192.168.1.100",
+			Name:          "test",
+			PrimaryDomain: "example.com",
+			VIP:           "192.168.1.100",
 		},
 		Network: &config.NetworkConfig{
 			Gateway: "192.168.1.1",

--- a/v1/cmd/foundry/commands/component/status.go
+++ b/v1/cmd/foundry/commands/component/status.go
@@ -42,21 +42,31 @@ func runStatus(ctx context.Context, cmd *cli.Command) error {
 		return component.ErrComponentNotFound(name)
 	}
 
+	// Load config using --config flag
+	configPath, err := config.FindConfig(cmd.String("config"))
+	if err != nil {
+		return fmt.Errorf("failed to find config: %w", err)
+	}
+
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+
 	fmt.Printf("Checking status of component: %s\n\n", name)
 
 	// Check status based on component name
 	var status *component.ComponentStatus
-	var err error
 
 	switch name {
 	case "openbao":
-		status, err = CheckOpenBAOStatus(ctx)
+		status, err = CheckOpenBAOStatus(ctx, cfg)
 	case "dns", "powerdns":
-		status, err = CheckDNSStatus(ctx)
+		status, err = CheckDNSStatus(ctx, cfg)
 	case "zot":
-		status, err = CheckZotStatus(ctx)
+		status, err = CheckZotStatus(ctx, cfg)
 	case "k3s", "kubernetes":
-		status, err = CheckK3sStatus(ctx)
+		status, err = CheckK3sStatus(ctx, cfg)
 	default:
 		return fmt.Errorf("status checking not implemented for component: %s", name)
 	}
@@ -85,17 +95,7 @@ func runStatus(ctx context.Context, cmd *cli.Command) error {
 }
 
 // CheckOpenBAOStatus checks the OpenBAO component status
-func CheckOpenBAOStatus(ctx context.Context) (*component.ComponentStatus, error) {
-	// Load config
-	cfg, err := config.Load(config.DefaultConfigPath())
-	if err != nil {
-		return &component.ComponentStatus{
-			Installed: false,
-			Healthy:   false,
-			Message:   fmt.Sprintf("failed to load config: %v", err),
-		}, nil
-	}
-
+func CheckOpenBAOStatus(ctx context.Context, cfg *config.Config) (*component.ComponentStatus, error) {
 	// Get OpenBAO host
 	h, err := cfg.GetPrimaryOpenBAOHost()
 	if err != nil {
@@ -196,17 +196,7 @@ func CheckOpenBAOStatus(ctx context.Context) (*component.ComponentStatus, error)
 }
 
 // CheckDNSStatus checks the DNS component status
-func CheckDNSStatus(ctx context.Context) (*component.ComponentStatus, error) {
-	// Load config
-	cfg, err := config.Load(config.DefaultConfigPath())
-	if err != nil {
-		return &component.ComponentStatus{
-			Installed: false,
-			Healthy:   false,
-			Message:   fmt.Sprintf("failed to load config: %v", err),
-		}, nil
-	}
-
+func CheckDNSStatus(ctx context.Context, cfg *config.Config) (*component.ComponentStatus, error) {
 	// Get DNS host
 	h, err := cfg.GetPrimaryDNSHost()
 	if err != nil {
@@ -312,17 +302,7 @@ func CheckDNSStatus(ctx context.Context) (*component.ComponentStatus, error) {
 }
 
 // CheckZotStatus checks the Zot component status
-func CheckZotStatus(ctx context.Context) (*component.ComponentStatus, error) {
-	// Load config
-	cfg, err := config.Load(config.DefaultConfigPath())
-	if err != nil {
-		return &component.ComponentStatus{
-			Installed: false,
-			Healthy:   false,
-			Message:   fmt.Sprintf("failed to load config: %v", err),
-		}, nil
-	}
-
+func CheckZotStatus(ctx context.Context, cfg *config.Config) (*component.ComponentStatus, error) {
 	// Get Zot host
 	h, err := cfg.GetPrimaryZotHost()
 	if err != nil {
@@ -406,17 +386,7 @@ func CheckZotStatus(ctx context.Context) (*component.ComponentStatus, error) {
 }
 
 // CheckK3sStatus checks the K3s component status
-func CheckK3sStatus(ctx context.Context) (*component.ComponentStatus, error) {
-	// Load config
-	cfg, err := config.Load(config.DefaultConfigPath())
-	if err != nil {
-		return &component.ComponentStatus{
-			Installed: false,
-			Healthy:   false,
-			Message:   fmt.Sprintf("failed to load config: %v", err),
-		}, nil
-	}
-
+func CheckK3sStatus(ctx context.Context, cfg *config.Config) (*component.ComponentStatus, error) {
 	// Get first cluster host
 	clusterHosts := cfg.GetClusterHosts()
 	if len(clusterHosts) == 0 {

--- a/v1/cmd/foundry/commands/component/status_test.go
+++ b/v1/cmd/foundry/commands/component/status_test.go
@@ -47,16 +47,16 @@ func TestStatusCommand(t *testing.T) {
 			errorContains: "not found",
 		},
 		{
-			name:         "valid component - openbao",
-			args:         []string{"test", "status", "openbao"},
-			expectError:  false,
-			expectOutput: []string{"Checking status", "openbao", "Installed:"},
+			name:          "valid component - openbao (no config)",
+			args:          []string{"test", "status", "openbao"},
+			expectError:   true,
+			errorContains: "failed to find config",
 		},
 		{
-			name:         "valid component - dns",
-			args:         []string{"test", "status", "dns"},
-			expectError:  false,
-			expectOutput: []string{"Checking status", "dns", "Installed:"},
+			name:          "valid component - dns (no config)",
+			args:          []string{"test", "status", "dns"},
+			expectError:   true,
+			errorContains: "failed to find config",
 		},
 	}
 

--- a/v1/cmd/foundry/commands/config/list.go
+++ b/v1/cmd/foundry/commands/config/list.go
@@ -71,7 +71,7 @@ func runList(ctx context.Context, cmd *cli.Command) error {
 
 		// Display config info
 		fmt.Printf("  %s %s\n", marker, name)
-		fmt.Printf("      Cluster: %s (%s)\n", cfg.Cluster.Name, cfg.Cluster.Domain)
+		fmt.Printf("      Cluster: %s (%s)\n", cfg.Cluster.Name, cfg.Cluster.PrimaryDomain)
 		fmt.Printf("      Hosts: %d, Components: %d\n", len(cfg.Hosts), len(cfg.Components))
 	}
 

--- a/v1/cmd/foundry/commands/config/validate.go
+++ b/v1/cmd/foundry/commands/config/validate.go
@@ -44,7 +44,7 @@ func runValidate(ctx context.Context, cmd *cli.Command) error {
 	}
 
 	fmt.Printf("✓ Configuration is valid: %s\n", configPath)
-	fmt.Printf("  Cluster: %s (%s)\n", cfg.Cluster.Name, cfg.Cluster.Domain)
+	fmt.Printf("  Cluster: %s (%s)\n", cfg.Cluster.Name, cfg.Cluster.PrimaryDomain)
 	fmt.Printf("  Hosts: %d\n", len(cfg.Hosts))
 	fmt.Printf("  Components: %d\n", len(cfg.Components))
 

--- a/v1/cmd/foundry/commands/dns/commands_test.go
+++ b/v1/cmd/foundry/commands/dns/commands_test.go
@@ -175,9 +175,9 @@ func setupTestConfig(t *testing.T) (string, *httptest.Server) {
 			APIKey:     "test-api-key", // Plain value for testing (not a secret ref)
 		},
 		Cluster: config.ClusterConfig{
-			Name:   "test-cluster",
-			Domain: "example.com",
-			VIP:    "192.168.1.100",
+			Name:          "test-cluster",
+			PrimaryDomain: "example.com",
+			VIP:           "192.168.1.100",
 		},
 		Components: config.ComponentMap{
 			"openbao": config.ComponentConfig{},

--- a/v1/cmd/foundry/commands/host/configure_test.go
+++ b/v1/cmd/foundry/commands/host/configure_test.go
@@ -59,8 +59,8 @@ func TestRunConfigure_NoSSHKey(t *testing.T) {
 	// Create a test config file
 	testConfig := &config.Config{
 		Cluster: config.ClusterConfig{
-			Name:   "test-cluster",
-			Domain: "example.com",
+			Name:          "test-cluster",
+			PrimaryDomain: "example.com",
 		},
 		Network: &config.NetworkConfig{
 			Gateway: "192.168.1.1",

--- a/v1/cmd/foundry/commands/host/list_test.go
+++ b/v1/cmd/foundry/commands/host/list_test.go
@@ -25,9 +25,9 @@ func setupTestConfigWithHosts(t *testing.T, hosts []*host.Host) string {
 
 	cfg := &config.Config{
 		Cluster: config.ClusterConfig{
-			Name:   "test-cluster",
-			Domain: "test.local",
-			VIP:    "192.168.1.100",
+			Name:          "test-cluster",
+			PrimaryDomain: "test.local",
+			VIP:           "192.168.1.100",
 		},
 		Components: config.ComponentMap{
 			"openbao": config.ComponentConfig{},

--- a/v1/cmd/foundry/commands/network/commands_test.go
+++ b/v1/cmd/foundry/commands/network/commands_test.go
@@ -72,7 +72,7 @@ func TestConfigSaveLoad(t *testing.T) {
 			},
 			Cluster: config.ClusterConfig{
 				Name:   "test-cluster",
-				Domain: "example.com",
+				PrimaryDomain: "example.com",
 				VIP:    "192.168.1.100",
 			},
 			Components: config.ComponentMap{
@@ -126,7 +126,7 @@ func TestConfigSaveLoad(t *testing.T) {
 			},
 			Cluster: config.ClusterConfig{
 				Name:   "test",
-				Domain: "example.com",
+				PrimaryDomain: "example.com",
 				VIP:    "192.168.1.100",
 			},
 			Components: config.ComponentMap{

--- a/v1/cmd/foundry/commands/stack/install_test.go
+++ b/v1/cmd/foundry/commands/stack/install_test.go
@@ -102,9 +102,9 @@ func createTestConfig(t *testing.T) *config.Config {
 			},
 		},
 		Cluster: config.ClusterConfig{
-			Name:   "test-cluster",
-			Domain: "example.com",
-			VIP:    "192.168.1.100",
+			Name:          "test-cluster",
+			PrimaryDomain: "example.com",
+			VIP:           "192.168.1.100",
 		},
 		Components: config.ComponentMap{
 			"openbao": {},
@@ -152,7 +152,7 @@ func TestValidateStackConfig(t *testing.T) {
 				},
 				Cluster: config.ClusterConfig{
 					Name:   "test",
-					Domain: "example.com",
+					PrimaryDomain: "example.com",
 				},
 				Components: config.ComponentMap{
 					"k3s": {},
@@ -176,7 +176,7 @@ func TestValidateStackConfig(t *testing.T) {
 				},
 				Cluster: config.ClusterConfig{
 					Name:   "test",
-					Domain: "example.com",
+					PrimaryDomain: "example.com",
 				},
 				Components: config.ComponentMap{
 					"k3s": {},
@@ -200,7 +200,7 @@ func TestValidateStackConfig(t *testing.T) {
 				},
 				Cluster: config.ClusterConfig{
 					Name:   "test",
-					Domain: "example.com",
+					PrimaryDomain: "example.com",
 				},
 				Hosts: []*host.Host{
 					{Hostname: "openbao1", Address: "192.168.1.10", Roles: []string{host.RoleOpenBAO}},
@@ -227,7 +227,7 @@ func TestValidateStackConfig(t *testing.T) {
 				},
 				Cluster: config.ClusterConfig{
 					Name:   "test",
-					Domain: "example.com",
+					PrimaryDomain: "example.com",
 					// VIP is intentionally missing
 				},
 				Hosts: []*host.Host{
@@ -257,7 +257,7 @@ func TestValidateStackConfig(t *testing.T) {
 				},
 				Cluster: config.ClusterConfig{
 					Name:   "test",
-					Domain: "example.com",
+					PrimaryDomain: "example.com",
 					VIP:    "192.168.1.100",
 				},
 				Hosts: []*host.Host{
@@ -287,7 +287,7 @@ func TestValidateStackConfig(t *testing.T) {
 				},
 				Cluster: config.ClusterConfig{
 					Name:   "test",
-					Domain: "example.com",
+					PrimaryDomain: "example.com",
 					VIP:    "192.168.1.100",
 				},
 				Hosts: []*host.Host{
@@ -316,7 +316,7 @@ func TestValidateStackConfig(t *testing.T) {
 					APIKey:              "test-api-key",
 				},
 				Cluster: config.ClusterConfig{
-					Domain: "example.com",
+					PrimaryDomain: "example.com",
 					VIP:    "192.168.1.100",
 					// Name intentionally missing
 				},
@@ -347,7 +347,7 @@ func TestValidateStackConfig(t *testing.T) {
 				},
 				Cluster: config.ClusterConfig{
 					Name:   "test",
-					Domain: "example.com",
+					PrimaryDomain: "example.com",
 					VIP:    "192.168.1.100",
 				},
 				Hosts: []*host.Host{

--- a/v1/cmd/foundry/commands/stack/status.go
+++ b/v1/cmd/foundry/commands/stack/status.go
@@ -24,7 +24,7 @@ func runStackStatus(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("failed to find config: %w", err)
 	}
 
-	_, err = config.Load(configPath)
+	cfg, err := config.Load(configPath)
 	if err != nil {
 		return fmt.Errorf("failed to load config: %w", err)
 	}
@@ -44,13 +44,13 @@ func runStackStatus(ctx context.Context, cmd *cli.Command) error {
 		// Use the same checking logic as component status command
 		switch compName {
 		case "openbao":
-			status, err = component.CheckOpenBAOStatus(ctx)
+			status, err = component.CheckOpenBAOStatus(ctx, cfg)
 		case "dns":
-			status, err = component.CheckDNSStatus(ctx)
+			status, err = component.CheckDNSStatus(ctx, cfg)
 		case "zot":
-			status, err = component.CheckZotStatus(ctx)
+			status, err = component.CheckZotStatus(ctx, cfg)
 		case "k3s":
-			status, err = component.CheckK3sStatus(ctx)
+			status, err = component.CheckK3sStatus(ctx, cfg)
 		case "contour", "cert-manager":
 			// These components don't have dedicated status checkers yet
 			comp := internalComponent.Get(compName)

--- a/v1/cmd/foundry/commands/stack/validate_test.go
+++ b/v1/cmd/foundry/commands/stack/validate_test.go
@@ -47,8 +47,8 @@ func TestValidateConfigStructure(t *testing.T) {
 					APIKey:              "test-key",
 				},
 				Cluster: config.ClusterConfig{
-					Name:   "test-cluster",
-					Domain: "example.com",
+					Name:          "test-cluster",
+					PrimaryDomain: "example.com",
 				},
 				Components: config.ComponentMap{
 					"openbao": {},
@@ -70,8 +70,8 @@ func TestValidateConfigStructure(t *testing.T) {
 					APIKey:              "test-key",
 				},
 				Cluster: config.ClusterConfig{
-					Name:   "test-cluster",
-					Domain: "example.com",
+					Name:          "test-cluster",
+					PrimaryDomain: "example.com",
 				},
 				Components: config.ComponentMap{
 					"openbao": {},
@@ -94,9 +94,9 @@ func TestValidateConfigStructure(t *testing.T) {
 					APIKey:              "test-key",
 				},
 				Cluster: config.ClusterConfig{
-					Name:   "test-cluster",
-					Domain: "example.com",
-					VIP:    "192.168.1.10", // Same as host below
+					Name:          "test-cluster",
+					PrimaryDomain: "example.com",
+					VIP:           "192.168.1.10", // Same as host below
 				},
 				Hosts: []*host.Host{
 					{
@@ -127,9 +127,9 @@ func TestValidateConfigStructure(t *testing.T) {
 					APIKey:              "test-key",
 				},
 				Cluster: config.ClusterConfig{
-					Name:   "test-cluster",
-					Domain: "example.com",
-					},
+					Name:          "test-cluster",
+					PrimaryDomain: "example.com",
+				},
 				Components: config.ComponentMap{}, // Empty!
 			},
 			wantErr: true,
@@ -174,8 +174,8 @@ func TestValidateSecretReferences(t *testing.T) {
 					APIKey:              "${secret:foundry-core/dns:api_key}",
 				},
 				Cluster: config.ClusterConfig{
-					Name:   "test-cluster",
-					Domain: "example.com",
+					Name:          "test-cluster",
+					PrimaryDomain: "example.com",
 				},
 				Components: config.ComponentMap{
 					"openbao": {},
@@ -197,8 +197,8 @@ func TestValidateSecretReferences(t *testing.T) {
 					APIKey:              "${secret:invalid-format}", // Missing :key part
 				},
 				Cluster: config.ClusterConfig{
-					Name:   "test-cluster",
-					Domain: "example.com",
+					Name:          "test-cluster",
+					PrimaryDomain: "example.com",
 				},
 				Components: config.ComponentMap{
 					"openbao": {},
@@ -221,8 +221,8 @@ func TestValidateSecretReferences(t *testing.T) {
 					APIKey:              "plain-text-key",
 				},
 				Cluster: config.ClusterConfig{
-					Name:   "test-cluster",
-					Domain: "example.com",
+					Name:          "test-cluster",
+					PrimaryDomain: "example.com",
 				},
 				Components: config.ComponentMap{
 					"openbao": {},
@@ -506,8 +506,8 @@ func TestValidateClusterConfig(t *testing.T) {
 			name: "valid cluster config",
 			cfg: &config.Config{
 				Cluster: config.ClusterConfig{
-					Name:   "test-cluster",
-					Domain: "example.com",
+					Name:          "test-cluster",
+					PrimaryDomain: "example.com",
 				},
 				Hosts: []*host.Host{
 					{
@@ -523,8 +523,8 @@ func TestValidateClusterConfig(t *testing.T) {
 			name: "no nodes",
 			cfg: &config.Config{
 				Cluster: config.ClusterConfig{
-					Name:   "test-cluster",
-					Domain: "example.com",
+					Name:          "test-cluster",
+					PrimaryDomain: "example.com",
 				},
 			},
 			wantErr: true,
@@ -534,8 +534,8 @@ func TestValidateClusterConfig(t *testing.T) {
 			name: "multiple nodes",
 			cfg: &config.Config{
 				Cluster: config.ClusterConfig{
-					Name:   "test-cluster",
-					Domain: "example.com",
+					Name:          "test-cluster",
+					PrimaryDomain: "example.com",
 				},
 				Hosts: []*host.Host{
 					{
@@ -644,9 +644,9 @@ func TestRunStackValidate_Integration(t *testing.T) {
 			APIKey:              "test-key",
 		},
 		Cluster: config.ClusterConfig{
-			Name:   "test-cluster",
-			Domain: "example.com",
-			VIP:    "192.168.1.100",
+			Name:          "test-cluster",
+			PrimaryDomain: "example.com",
+			VIP:           "192.168.1.100",
 		},
 		Hosts: []*host.Host{
 			{
@@ -690,9 +690,9 @@ func TestRunStackValidate_Integration(t *testing.T) {
 				APIKey:              "test-key",
 			},
 			Cluster: config.ClusterConfig{
-				Name:   "test-cluster",
-				Domain: "example.com",
-				VIP:    "10.0.0.100", // IP not on same network as 192.168.1.0/24
+				Name:          "test-cluster",
+				PrimaryDomain: "example.com",
+				VIP:           "10.0.0.100", // IP not on same network as 192.168.1.0/24
 			},
 			Hosts: []*host.Host{
 				{Hostname: "test-host", Address: "192.168.1.10", Roles: []string{host.RoleOpenBAO}},

--- a/v1/cmd/foundry/commands/storage/list_test.go
+++ b/v1/cmd/foundry/commands/storage/list_test.go
@@ -28,9 +28,9 @@ func TestListCommand_EmptyStorage(t *testing.T) {
 
 	cfg := &config.Config{
 		Cluster: config.ClusterConfig{
-			Name:   "test",
-			Domain: "test.local",
-			VIP:    "192.168.1.100",
+			Name:          "test",
+			PrimaryDomain: "test.local",
+			VIP:           "192.168.1.100",
 		},
 		Components: config.ComponentMap{
 			"k3s": config.ComponentConfig{},
@@ -53,9 +53,9 @@ func TestListCommand_WithLonghorn(t *testing.T) {
 
 	cfg := &config.Config{
 		Cluster: config.ClusterConfig{
-			Name:   "test",
-			Domain: "test.local",
-			VIP:    "192.168.1.100",
+			Name:          "test",
+			PrimaryDomain: "test.local",
+			VIP:           "192.168.1.100",
 		},
 		Components: config.ComponentMap{
 			"k3s": config.ComponentConfig{},
@@ -82,9 +82,9 @@ func TestListCommand_WithLocalPath(t *testing.T) {
 
 	cfg := &config.Config{
 		Cluster: config.ClusterConfig{
-			Name:   "test",
-			Domain: "test.local",
-			VIP:    "192.168.1.100",
+			Name:          "test",
+			PrimaryDomain: "test.local",
+			VIP:           "192.168.1.100",
 		},
 		Components: config.ComponentMap{
 			"k3s": config.ComponentConfig{},
@@ -111,9 +111,9 @@ func TestListCommand_WithNFS(t *testing.T) {
 
 	cfg := &config.Config{
 		Cluster: config.ClusterConfig{
-			Name:   "test",
-			Domain: "test.local",
-			VIP:    "192.168.1.100",
+			Name:          "test",
+			PrimaryDomain: "test.local",
+			VIP:           "192.168.1.100",
 		},
 		Components: config.ComponentMap{
 			"k3s": config.ComponentConfig{},
@@ -150,8 +150,8 @@ func TestStorageBackendTypes(t *testing.T) {
 
 			cfg := &config.Config{
 				Cluster: config.ClusterConfig{
-					Name:   "test",
-					Domain: "test.local",
+					Name:          "test",
+					PrimaryDomain: "test.local",
 				},
 				Components: config.ComponentMap{
 					"k3s": config.ComponentConfig{},

--- a/v1/cmd/foundry/main.go
+++ b/v1/cmd/foundry/main.go
@@ -56,6 +56,16 @@ func main() {
 				Sources: cli.EnvVars("FOUNDRY_CONFIG"),
 			},
 		},
+		Before: func(ctx context.Context, cmd *cli.Command) (context.Context, error) {
+			// Re-initialize host registry with the config path from --config flag
+			configFlag := cmd.String("config")
+			if configFlag != "" {
+				if err := registry.InitHostRegistryWithConfig(configFlag); err != nil {
+					return ctx, fmt.Errorf("failed to initialize host registry with config %s: %w", configFlag, err)
+				}
+			}
+			return ctx, nil
+		},
 		Commands: []*cli.Command{
 			backupcmd.Command,
 			clustercmd.Commands(),

--- a/v1/cmd/foundry/registry/host.go
+++ b/v1/cmd/foundry/registry/host.go
@@ -11,13 +11,28 @@ import (
 // This loads hosts from the stack configuration file and makes them available
 // to all commands that use host.Get(), host.List(), etc.
 func InitHostRegistry() error {
-	// Get default config path
-	configPath := config.DefaultConfigPath()
+	return InitHostRegistryWithConfig("")
+}
+
+// InitHostRegistryWithConfig initializes the global host registry with a specific config path.
+// If configPath is empty, it uses FindConfig to resolve the path (respecting --config flag).
+func InitHostRegistryWithConfig(configPath string) error {
+	// Resolve config path if not provided
+	if configPath == "" {
+		var err error
+		configPath, err = config.FindConfig("")
+		if err != nil {
+			// Config doesn't exist yet (first run), create empty in-memory registry
+			// Commands like 'config init' need to work before config exists
+			registry := host.NewMemoryRegistry()
+			host.SetDefaultRegistry(registry)
+			return nil
+		}
+	}
 
 	// Check if config exists
 	if _, err := os.Stat(configPath); os.IsNotExist(err) {
 		// If config doesn't exist yet (first run), create empty in-memory registry
-		// Commands like 'config init' need to work before config exists
 		registry := host.NewMemoryRegistry()
 		host.SetDefaultRegistry(registry)
 		return nil

--- a/v1/internal/component/k3s/controlplane_test.go
+++ b/v1/internal/component/k3s/controlplane_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/catalystcommunity/foundry/v1/internal/ssh"
 	"github.com/stretchr/testify/assert"
@@ -203,6 +204,12 @@ func TestJoinControlPlane(t *testing.T) {
 }
 
 func TestVerifyNodeJoined(t *testing.T) {
+	// Use fast retry config for tests
+	fastRetryCfg := RetryConfig{
+		MaxRetries: 2,
+		RetryDelay: 10 * time.Millisecond,
+	}
+
 	tests := []struct {
 		name          string
 		exec          func(command string) (*ssh.ExecResult, error)
@@ -272,7 +279,7 @@ func TestVerifyNodeJoined(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			executor := &mockControlPlaneExecutor{execFunc: tt.exec}
-			err := verifyNodeJoined(executor)
+			err := verifyNodeJoined(executor, fastRetryCfg)
 
 			if tt.expectError {
 				require.Error(t, err)

--- a/v1/internal/component/k3s/install_test.go
+++ b/v1/internal/component/k3s/install_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/catalystcommunity/foundry/v1/internal/ssh"
 	"github.com/stretchr/testify/assert"
@@ -333,6 +334,12 @@ func TestCreateRegistriesConfig(t *testing.T) {
 }
 
 func TestWaitForK3sReady(t *testing.T) {
+	// Use fast retry config for tests
+	fastRetryCfg := RetryConfig{
+		MaxRetries: 5,
+		RetryDelay: 10 * time.Millisecond,
+	}
+
 	tests := []struct {
 		name    string
 		exec    func(command string) (*ssh.ExecResult, error)
@@ -370,7 +377,7 @@ func TestWaitForK3sReady(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			executor := &mockInstallSSHExecutor{execFunc: tt.exec}
-			err := waitForK3sReady(executor)
+			err := waitForK3sReady(executor, fastRetryCfg)
 
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -435,6 +442,12 @@ func TestSetupKubeVIP(t *testing.T) {
 }
 
 func TestWaitForKubeVIPReady(t *testing.T) {
+	// Use fast retry config for tests
+	fastRetryCfg := RetryConfig{
+		MaxRetries: 5,
+		RetryDelay: 10 * time.Millisecond,
+	}
+
 	tests := []struct {
 		name    string
 		vip     string
@@ -475,7 +488,7 @@ func TestWaitForKubeVIPReady(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			executor := &mockInstallSSHExecutor{execFunc: tt.exec}
-			err := waitForKubeVIPReady(executor, tt.vip)
+			err := waitForKubeVIPReady(executor, tt.vip, fastRetryCfg)
 
 			if tt.wantErr {
 				assert.Error(t, err)

--- a/v1/internal/component/k3s/worker_test.go
+++ b/v1/internal/component/k3s/worker_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/catalystcommunity/foundry/v1/internal/ssh"
 	"github.com/stretchr/testify/assert"
@@ -302,6 +303,12 @@ func TestGenerateK3sAgentInstallCommand(t *testing.T) {
 }
 
 func TestWaitForK3sAgentReady(t *testing.T) {
+	// Use fast retry config for tests
+	fastRetryCfg := RetryConfig{
+		MaxRetries: 5,
+		RetryDelay: 10 * time.Millisecond,
+	}
+
 	tests := []struct {
 		name          string
 		exec          func(command string) (*ssh.ExecResult, error)
@@ -336,7 +343,7 @@ func TestWaitForK3sAgentReady(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			executor := &mockWorkerExecutor{execFunc: tt.exec}
-			err := waitForK3sAgentReady(executor)
+			err := waitForK3sAgentReady(executor, fastRetryCfg)
 
 			if tt.expectError {
 				require.Error(t, err)

--- a/v1/internal/config/dns_test.go
+++ b/v1/internal/config/dns_test.go
@@ -58,7 +58,7 @@ func TestDNSConfig_Validate(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "duplicate zone names",
+			name: "duplicate zone names allowed",
 			config: DNSConfig{
 				InfrastructureZones: []DNSZone{
 					{Name: "example.com", Public: true, PublicCNAME: strPtr("home.example.com")},
@@ -69,8 +69,7 @@ func TestDNSConfig_Validate(t *testing.T) {
 				Backend: "sqlite",
 				APIKey:  "test-key",
 			},
-			wantErr: true,
-			errMsg:  "duplicate zone name",
+			wantErr: false, // Duplicates are allowed and deduplicated during zone creation
 		},
 		{
 			name: "missing backend",
@@ -216,9 +215,9 @@ func TestConfig_WithNetworkAndDNS(t *testing.T) {
 			APIKey:  "${secret:foundry-core/dns:api_key}",
 		},
 		Cluster: ClusterConfig{
-			Name:   "test",
-			Domain: "example.com",
-			VIP:    "192.168.1.100",
+			Name:          "test",
+			PrimaryDomain: "example.com",
+			VIP:           "192.168.1.100",
 		},
 		Components: ComponentMap{
 			"k3s": ComponentConfig{},

--- a/v1/internal/config/loader_test.go
+++ b/v1/internal/config/loader_test.go
@@ -125,7 +125,7 @@ func TestLoad_ValidConfigFile(t *testing.T) {
 
 	// Verify some key fields
 	assert.Equal(t, "production", config.Cluster.Name)
-	assert.Equal(t, "example.com", config.Cluster.Domain)
+	assert.Equal(t, "example.com", config.Cluster.PrimaryDomain)
 
 	// Verify hosts (nodes are now in hosts array with cluster-* roles)
 	clusterHosts := config.GetClusterControlPlaneHosts()

--- a/v1/internal/config/network_test.go
+++ b/v1/internal/config/network_test.go
@@ -187,8 +187,8 @@ func TestConfig_ValidateVIPUniqueness(t *testing.T) {
 					},
 				},
 				Cluster: ClusterConfig{
-					Name:   "test",
-					Domain: "example.com",
+					Name:          "test",
+					PrimaryDomain: "example.com",
 					VIP:    "192.168.1.100",
 				},
 				Components: ComponentMap{"k3s": ComponentConfig{}},
@@ -210,8 +210,8 @@ func TestConfig_ValidateVIPUniqueness(t *testing.T) {
 					},
 				},
 				Cluster: ClusterConfig{
-					Name:   "test",
-					Domain: "example.com",
+					Name:          "test",
+					PrimaryDomain: "example.com",
 					VIP:    "192.168.1.10", // Conflicts with host1
 				},
 				Components: ComponentMap{"k3s": ComponentConfig{}},
@@ -234,8 +234,8 @@ func TestConfig_ValidateVIPUniqueness(t *testing.T) {
 					},
 				},
 				Cluster: ClusterConfig{
-					Name:   "test",
-					Domain: "example.com",
+					Name:          "test",
+					PrimaryDomain: "example.com",
 					VIP:    "192.168.1.20", // Conflicts with node1
 				},
 				Components: ComponentMap{"k3s": ComponentConfig{}},

--- a/v1/internal/config/resolve_test.go
+++ b/v1/internal/config/resolve_test.go
@@ -35,7 +35,7 @@ func TestValidateSecretRefs(t *testing.T) {
 			config: &Config{
 				Cluster: ClusterConfig{
 					Name:   "${secret:foundry-core/cluster:name}",
-					Domain: "example.com",
+					PrimaryDomain: "example.com",
 				},
 				Components: ComponentMap{
 					"k3s": ComponentConfig{},
@@ -48,7 +48,7 @@ func TestValidateSecretRefs(t *testing.T) {
 			config: &Config{
 				Cluster: ClusterConfig{
 					Name:   "${secret:invalid}",
-					Domain: "example.com",
+					PrimaryDomain: "example.com",
 				},
 				Components: ComponentMap{
 					"k3s": ComponentConfig{},
@@ -62,7 +62,7 @@ func TestValidateSecretRefs(t *testing.T) {
 			config: &Config{
 				Cluster: ClusterConfig{
 					Name:   "test",
-					Domain: "example.com",
+					PrimaryDomain: "example.com",
 				},
 				Components: ComponentMap{
 					"k3s": ComponentConfig{Version: strPtr("v1.28.5")},
@@ -100,7 +100,7 @@ func TestResolveSecrets(t *testing.T) {
 			config: &Config{
 				Cluster: ClusterConfig{
 					Name:   "${secret:cluster:name}",
-					Domain: "example.com",
+					PrimaryDomain: "example.com",
 				},
 				Components: ComponentMap{
 					"k3s": ComponentConfig{},
@@ -122,7 +122,7 @@ func TestResolveSecrets(t *testing.T) {
 			config: &Config{
 				Cluster: ClusterConfig{
 					Name:   "${secret:cluster:name}",
-					Domain: "${secret:cluster:domain}",
+					PrimaryDomain: "${secret:cluster:primary_domain}",
 				},
 				Components: ComponentMap{
 					"k3s": ComponentConfig{},
@@ -132,13 +132,13 @@ func TestResolveSecrets(t *testing.T) {
 			resolver: &mockSecretResolver{
 				values: map[string]string{
 					"foundry-core/cluster:name":   "resolved-name",
-					"foundry-core/cluster:domain": "resolved.example.com",
+					"foundry-core/cluster:primary_domain": "resolved.example.com",
 				},
 			},
 			wantErr: false,
 			check: func(t *testing.T, cfg *Config) {
 				assert.Equal(t, "resolved-name", cfg.Cluster.Name)
-				assert.Equal(t, "resolved.example.com", cfg.Cluster.Domain)
+				assert.Equal(t, "resolved.example.com", cfg.Cluster.PrimaryDomain)
 			},
 		},
 		{
@@ -146,7 +146,7 @@ func TestResolveSecrets(t *testing.T) {
 			config: &Config{
 				Cluster: ClusterConfig{
 					Name:   "${secret:cluster:name}",
-					Domain: "example.com",
+					PrimaryDomain: "example.com",
 				},
 				Components: ComponentMap{
 					"k3s": ComponentConfig{},
@@ -164,7 +164,7 @@ func TestResolveSecrets(t *testing.T) {
 			config: &Config{
 				Cluster: ClusterConfig{
 					Name:   "test",
-					Domain: "example.com",
+					PrimaryDomain: "example.com",
 				},
 				Components: ComponentMap{
 					"k3s": ComponentConfig{Version: strPtr("v1.28.5")},
@@ -203,7 +203,7 @@ func TestResolveSecrets_NilParameters(t *testing.T) {
 	config := &Config{
 		Cluster: ClusterConfig{
 			Name:   "test",
-			Domain: "example.com",
+			PrimaryDomain: "example.com",
 		},
 		Components: ComponentMap{
 			"k3s": ComponentConfig{},

--- a/v1/internal/config/types.gen.go
+++ b/v1/internal/config/types.gen.go
@@ -40,7 +40,8 @@ type DNSZone struct {
 // ClusterConfig represents a structured data type
 type ClusterConfig struct {
 	Name string `json:"name" yaml:"name"`
-	Domain string `json:"domain" yaml:"domain"`
+	Domain *string `json:"domain,omitempty" yaml:"domain,omitempty"`
+	PrimaryDomain string `json:"primary_domain" yaml:"primary_domain"`
 	VIP string `json:"vip" yaml:"vip"`
 }
 

--- a/v1/internal/config/types.go
+++ b/v1/internal/config/types.go
@@ -199,20 +199,8 @@ func (d *DNSConfig) Validate() error {
 		}
 	}
 
-	// Validate zone name uniqueness across both lists
-	zoneNames := make(map[string]bool)
-	for _, zone := range d.InfrastructureZones {
-		if zoneNames[zone.Name] {
-			return fmt.Errorf("duplicate zone name: %q", zone.Name)
-		}
-		zoneNames[zone.Name] = true
-	}
-	for _, zone := range d.KubernetesZones {
-		if zoneNames[zone.Name] {
-			return fmt.Errorf("duplicate zone name: %q", zone.Name)
-		}
-		zoneNames[zone.Name] = true
-	}
+	// Note: Duplicate zone names across infrastructure_zones and kubernetes_zones
+	// are allowed - they will be deduplicated during zone creation in createDNSZones
 
 	// Validate backend
 	if d.Backend == "" {

--- a/v1/internal/config/types_test.go
+++ b/v1/internal/config/types_test.go
@@ -20,8 +20,8 @@ func TestConfig_Validate(t *testing.T) {
 			name: "valid minimal config",
 			config: Config{
 				Cluster: ClusterConfig{
-					Name:   "test",
-					Domain: "example.com",
+					Name:          "test",
+					PrimaryDomain: "example.com",
 				},
 				Components: ComponentMap{
 					"k3s": ComponentConfig{},
@@ -33,8 +33,8 @@ func TestConfig_Validate(t *testing.T) {
 			name: "no components",
 			config: Config{
 				Cluster: ClusterConfig{
-					Name:   "test",
-					Domain: "example.com",
+					Name:          "test",
+					PrimaryDomain: "example.com",
 				},
 				Components: ComponentMap{},
 			},
@@ -127,7 +127,7 @@ func TestConfig_UnmarshalYAML(t *testing.T) {
 version: "1.0"
 cluster:
   name: test-cluster
-  domain: test.com
+  primary_domain: test.com
   vip: 192.168.1.100
 
 network:
@@ -171,7 +171,7 @@ storage:
 	require.NoError(t, err)
 
 	assert.Equal(t, "test-cluster", config.Cluster.Name)
-	assert.Equal(t, "test.com", config.Cluster.Domain)
+	assert.Equal(t, "test.com", config.Cluster.PrimaryDomain)
 	assert.Equal(t, "192.168.1.100", config.Cluster.VIP)
 
 	// Verify hosts

--- a/v1/internal/network/validate_test.go
+++ b/v1/internal/network/validate_test.go
@@ -40,8 +40,8 @@ func TestValidateIPs(t *testing.T) {
 					},
 				},
 				Cluster: config.ClusterConfig{
-					Name:   "test",
-					Domain: "example.com",
+					Name:          "test",
+					PrimaryDomain: "example.com",
 					VIP:    "192.168.1.100",
 				},
 				Components: config.ComponentMap{
@@ -65,8 +65,8 @@ func TestValidateIPs(t *testing.T) {
 					},
 				},
 				Cluster: config.ClusterConfig{
-					Name:   "test",
-					Domain: "example.com",
+					Name:          "test",
+					PrimaryDomain: "example.com",
 					VIP:    "192.168.1.100",
 				},
 				Components: config.ComponentMap{
@@ -91,8 +91,8 @@ func TestValidateIPs(t *testing.T) {
 					},
 				},
 				Cluster: config.ClusterConfig{
-					Name:   "test",
-					Domain: "example.com",
+					Name:          "test",
+					PrimaryDomain: "example.com",
 					VIP:    "10.0.0.100", // Completely different network
 				},
 				Components: config.ComponentMap{
@@ -127,8 +127,8 @@ func TestValidateIPs(t *testing.T) {
 					},
 				},
 				Cluster: config.ClusterConfig{
-					Name:   "test",
-					Domain: "example.com",
+					Name:          "test",
+					PrimaryDomain: "example.com",
 					VIP:    "192.168.1.100",
 				},
 				Components: config.ComponentMap{
@@ -157,8 +157,8 @@ func TestValidateIPs(t *testing.T) {
 					},
 				},
 				Cluster: config.ClusterConfig{
-					Name:   "test",
-					Domain: "example.com",
+					Name:          "test",
+					PrimaryDomain: "example.com",
 					VIP:    "192.168.1.100",
 				},
 				Components: config.ComponentMap{
@@ -275,8 +275,8 @@ func TestCheckDHCPConflicts(t *testing.T) {
 					},
 				},
 				Cluster: config.ClusterConfig{
-					Name:   "test",
-					Domain: "example.com",
+					Name:          "test",
+					PrimaryDomain: "example.com",
 					VIP:    "192.168.1.100",
 				},
 				Components: config.ComponentMap{
@@ -314,8 +314,8 @@ func TestCheckDHCPConflicts(t *testing.T) {
 					},
 				},
 				Cluster: config.ClusterConfig{
-					Name:   "test",
-					Domain: "example.com",
+					Name:          "test",
+					PrimaryDomain: "example.com",
 					VIP:    "192.168.1.100",
 				},
 				Components: config.ComponentMap{
@@ -343,8 +343,8 @@ func TestCheckDHCPConflicts(t *testing.T) {
 					},
 				},
 				Cluster: config.ClusterConfig{
-					Name:   "test",
-					Domain: "example.com",
+					Name:          "test",
+					PrimaryDomain: "example.com",
 					VIP:    "192.168.1.75", // Inside DHCP range
 				},
 				Components: config.ComponentMap{
@@ -373,8 +373,8 @@ func TestCheckDHCPConflicts(t *testing.T) {
 					},
 				},
 				Cluster: config.ClusterConfig{
-					Name:   "test",
-					Domain: "example.com",
+					Name:          "test",
+					PrimaryDomain: "example.com",
 					VIP:    "192.168.1.100",
 				},
 				Components: config.ComponentMap{
@@ -413,8 +413,8 @@ func TestCheckDHCPConflicts(t *testing.T) {
 					},
 				},
 				Cluster: config.ClusterConfig{
-					Name:   "test",
-					Domain: "example.com",
+					Name:          "test",
+					PrimaryDomain: "example.com",
 					VIP:    "192.168.1.100",
 				},
 				Components: config.ComponentMap{
@@ -443,8 +443,8 @@ func TestCheckDHCPConflicts(t *testing.T) {
 					},
 				},
 				Cluster: config.ClusterConfig{
-					Name:   "test",
-					Domain: "example.com",
+					Name:          "test",
+					PrimaryDomain: "example.com",
 					VIP:    "192.168.1.100",
 				},
 				Components: config.ComponentMap{
@@ -473,8 +473,8 @@ func TestCheckDHCPConflicts(t *testing.T) {
 					},
 				},
 				Cluster: config.ClusterConfig{
-					Name:   "test",
-					Domain: "example.com",
+					Name:          "test",
+					PrimaryDomain: "example.com",
 					VIP:    "192.168.1.99", // Exactly at end
 				},
 				Components: config.ComponentMap{
@@ -503,8 +503,8 @@ func TestCheckDHCPConflicts(t *testing.T) {
 					},
 				},
 				Cluster: config.ClusterConfig{
-					Name:   "test",
-					Domain: "example.com",
+					Name:          "test",
+					PrimaryDomain: "example.com",
 					VIP:    "192.168.1.100",
 				},
 				Components: config.ComponentMap{


### PR DESCRIPTION
Mostly what it says on the tin. I reduced a lot of duplicate parsing of config file options so the root command is the source of truth of the config file. That refactoring may need to continue, but all in service of getting the DNS zone setup working from a fresh install. Tomorrow I will do a base install from scratch again and see if it works, but this should transition from any current state and be backwards compatible to new state including updating config files. Now if zones are not setup in powerdns, it updates those zones in the config file to also be in powerdns.

Also subcommands for DNS respect --config as well.