### PR TITLE
fix: full install on new VMs tested with these fixes

### DIFF
--- a/v1/cmd/foundry/commands/config/template.yaml
+++ b/v1/cmd/foundry/commands/config/template.yaml
@@ -3,12 +3,28 @@
 
 cluster:
   name: <CLUSTER_NAME>  # e.g., homelab, production
-  domain: <DOMAIN>  # e.g., lab.local, example.com
+  primary_domain: <PRIMARY_DOMAIN>  # e.g., lab.local, example.com
   vip: <VIP>  # K3s API VIP, e.g., 192.168.1.100
 
 network:
   gateway: <GATEWAY>  # e.g., 192.168.1.1
   netmask: <NETMASK>  # e.g., 255.255.255.0
+
+dns:
+  backend: sqlite
+  api_key: ${secret:foundry-core/dns:api_key}
+  forwarders:
+    - 1.1.1.1
+    - 8.8.8.8
+  # Infrastructure zones get A records for openbao, dns, zot, k8s
+  infrastructure_zones:
+    - name: <PRIMARY_DOMAIN>
+      public: false
+  # Kubernetes zones get wildcard records and are managed by external-dns
+  # Add additional domains here if needed
+  kubernetes_zones:
+    - name: <PRIMARY_DOMAIN>
+      public: false
 
 # Add your infrastructure hosts below
 # Each host needs roles assigned from:

--- a/v1/internal/component/openbao/keys.go
+++ b/v1/internal/component/openbao/keys.go
@@ -62,3 +62,13 @@ func KeyMaterialExists(keysDir string, clusterName string) bool {
 	_, err := os.Stat(keysPath)
 	return err == nil
 }
+
+// DeleteKeyMaterial removes key material for a cluster
+// This is used when OpenBAO was reset and old keys are stale
+func DeleteKeyMaterial(keysDir string, clusterName string) error {
+	clusterKeysDir := filepath.Join(keysDir, clusterName)
+	if err := os.RemoveAll(clusterKeysDir); err != nil {
+		return fmt.Errorf("failed to remove keys directory: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
In addition to fixing anything that went wrong in the install on fresh VMs, I also added a convenience of caching the root password on a multi-node stack install so that if we need to setup sudo on a bunch of nodes in the stack install, we don't need to enter the password multiple times. This made testing something I could largely just wait on instead of having to stay attentive every loop.