### PR TITLE
feat: additional registries support

### DIFF
--- a/csil/v1/components/k3s.csil
+++ b/csil/v1/components/k3s.csil
@@ -21,6 +21,18 @@ Config = {
     cluster_init: bool @go_name("ClusterInit"),
     server_url: text @go_name("ServerURL"),
     dns_servers: [* text] @go_name("DNSServers"),
+    ? additional_registries: [* AdditionalRegistry] @go_name("AdditionalRegistries"),
+}
+
+; Additional registry configuration for user-defined registries
+; beyond the auto-generated zot mirrors
+AdditionalRegistry = {
+    name: text @go_name("Name"),
+    ? endpoint: text @go_name("Endpoint"),
+    ? http: bool @go_name("HTTP"),
+    ? insecure: bool @go_name("Insecure"),
+    ? username: text @go_name("Username"),
+    ? password: text @go_name("Password"),
 }
 
 ; K3s registry configuration (registries.yaml format)

--- a/v1/cmd/foundry/commands/cluster/init.go
+++ b/v1/cmd/foundry/commands/cluster/init.go
@@ -286,9 +286,14 @@ func InitializeCluster(ctx context.Context, cfg *config.Config) error {
 		DisableComponents: []string{"traefik", "servicelb"},
 	}
 
+	// Parse additional registries from component config
+	if k3sCompCfg, exists := cfg.Components["k3s"]; exists {
+		k3sConfig.AdditionalRegistries = k3s.ParseAdditionalRegistries(k3sCompCfg.Config)
+	}
+
 	// Add registry config if Zot is configured
 	if zotAddr, err := cfg.GetPrimaryZotAddress(); err == nil {
-		k3sConfig.RegistryConfig = k3s.GenerateRegistriesConfig(zotAddr)
+		k3sConfig.RegistryConfig = k3s.GenerateRegistriesConfig(zotAddr, k3sConfig.AdditionalRegistries)
 	}
 
 	// Install control plane

--- a/v1/cmd/foundry/commands/cluster/node_add.go
+++ b/v1/cmd/foundry/commands/cluster/node_add.go
@@ -271,9 +271,14 @@ func addNodeToCluster(ctx context.Context, hostname string, nodeRole *k3s.Determ
 		DisableComponents: []string{"traefik", "servicelb"},
 	}
 
+	// Parse additional registries from component config
+	if k3sCompCfg, exists := cfg.Components["k3s"]; exists {
+		k3sConfig.AdditionalRegistries = k3s.ParseAdditionalRegistries(k3sCompCfg.Config)
+	}
+
 	// Add registry config if Zot is configured
 	if zotAddr, err := cfg.GetPrimaryZotAddress(); err == nil {
-		k3sConfig.RegistryConfig = k3s.GenerateRegistriesConfig(zotAddr)
+		k3sConfig.RegistryConfig = k3s.GenerateRegistriesConfig(zotAddr, k3sConfig.AdditionalRegistries)
 	}
 
 	// Step 5: Join node based on role

--- a/v1/cmd/foundry/commands/config/template.yaml
+++ b/v1/cmd/foundry/commands/config/template.yaml
@@ -56,6 +56,14 @@ components:
   k3s:
     version: latest
     ha: false  # Set to true for multi-control-plane
+    # additional_registries:
+    #   - name: "10.16.0.40:5000"       # Internal HTTP registry
+    #     http: true
+    #   - name: "registry.example.com"   # Private HTTPS registry
+    #     username: "user"
+    #     password: "pass"
+    #   - name: "selfsigned.corp:5000"   # Self-signed HTTPS registry
+    #     insecure: true
 
   zot:
     version: latest

--- a/v1/cmd/foundry/commands/openbao/unseal.go
+++ b/v1/cmd/foundry/commands/openbao/unseal.go
@@ -31,7 +31,10 @@ func runUnseal(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("failed to get home directory: %w", err)
 	}
 
-	configPath := config.DefaultConfigPath()
+	configPath, err := config.FindConfig(cmd.String("config"))
+	if err != nil {
+		return fmt.Errorf("failed to find config: %w", err)
+	}
 	stackConfig, err := config.Load(configPath)
 	if err != nil {
 		return fmt.Errorf("failed to load stack config: %w", err)

--- a/v1/cmd/foundry/commands/stack/install.go
+++ b/v1/cmd/foundry/commands/stack/install.go
@@ -773,6 +773,13 @@ func installComponents(ctx context.Context, cfg *config.Config, configPath strin
 						return fmt.Errorf("failed to ensure DNS zones: %w", err)
 					}
 				}
+				// K3s is installed but ensure registries.yaml is up to date
+				if comp.name == "k3s" {
+					fmt.Println("  Syncing K3s registry configuration...")
+					if err := installK3sCluster(ctx, cfg); err != nil {
+						return fmt.Errorf("failed to sync K3s registries: %w", err)
+					}
+				}
 				continue
 			}
 		} else {

--- a/v1/internal/component/k3s/types.gen.go
+++ b/v1/internal/component/k3s/types.gen.go
@@ -16,6 +16,17 @@ type Config struct {
 	ClusterInit bool `json:"cluster_init" yaml:"cluster_init"`
 	ServerURL string `json:"server_url" yaml:"server_url"`
 	DNSServers []string `json:"dns_servers" yaml:"dns_servers"`
+	AdditionalRegistries []AdditionalRegistry `json:"additional_registries,omitempty" yaml:"additional_registries,omitempty"`
+}
+
+// AdditionalRegistry represents a structured data type
+type AdditionalRegistry struct {
+	Name string `json:"name" yaml:"name"`
+	Endpoint *string `json:"endpoint,omitempty" yaml:"endpoint,omitempty"`
+	HTTP *bool `json:"http,omitempty" yaml:"http,omitempty"`
+	Insecure *bool `json:"insecure,omitempty" yaml:"insecure,omitempty"`
+	Username *string `json:"username,omitempty" yaml:"username,omitempty"`
+	Password *string `json:"password,omitempty" yaml:"password,omitempty"`
 }
 
 // RegistryConfig represents a structured data type

--- a/v1/internal/component/k3s/types.go
+++ b/v1/internal/component/k3s/types.go
@@ -109,7 +109,78 @@ func ParseConfig(cfg component.ComponentConfig) (*Config, error) {
 		config.DNSServers = dnsServers
 	}
 
+	// Additional registries
+	if raw, ok := cfg.Get("additional_registries"); ok {
+		if registries, ok := raw.([]interface{}); ok {
+			for _, entry := range registries {
+				if m, ok := entry.(map[string]interface{}); ok {
+					reg := AdditionalRegistry{}
+					if name, ok := m["name"].(string); ok {
+						reg.Name = name
+					}
+					if endpoint, ok := m["endpoint"].(string); ok {
+						reg.Endpoint = &endpoint
+					}
+					if httpVal, ok := m["http"].(bool); ok {
+						reg.HTTP = &httpVal
+					}
+					if insecure, ok := m["insecure"].(bool); ok {
+						reg.Insecure = &insecure
+					}
+					if username, ok := m["username"].(string); ok {
+						reg.Username = &username
+					}
+					if password, ok := m["password"].(string); ok {
+						reg.Password = &password
+					}
+					config.AdditionalRegistries = append(config.AdditionalRegistries, reg)
+				}
+			}
+		}
+	}
+
 	return config, nil
+}
+
+// ParseAdditionalRegistries parses additional registry entries from a raw config map.
+// This is used by callers that have a map[string]any rather than a component.ComponentConfig.
+func ParseAdditionalRegistries(raw map[string]any) []AdditionalRegistry {
+	val, ok := raw["additional_registries"]
+	if !ok {
+		return nil
+	}
+	registries, ok := val.([]interface{})
+	if !ok {
+		return nil
+	}
+	var result []AdditionalRegistry
+	for _, entry := range registries {
+		m, ok := entry.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		reg := AdditionalRegistry{}
+		if name, ok := m["name"].(string); ok {
+			reg.Name = name
+		}
+		if endpoint, ok := m["endpoint"].(string); ok {
+			reg.Endpoint = &endpoint
+		}
+		if httpVal, ok := m["http"].(bool); ok {
+			reg.HTTP = &httpVal
+		}
+		if insecure, ok := m["insecure"].(bool); ok {
+			reg.Insecure = &insecure
+		}
+		if username, ok := m["username"].(string); ok {
+			reg.Username = &username
+		}
+		if password, ok := m["password"].(string); ok {
+			reg.Password = &password
+		}
+		result = append(result, reg)
+	}
+	return result
 }
 
 // Validate validates the K3s configuration

--- a/v1/internal/container/install_test.go
+++ b/v1/internal/container/install_test.go
@@ -1,0 +1,230 @@
+package container
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockCommandExecutor is a mock for CommandExecutor interface
+type mockCommandExecutor struct {
+	commands    map[string]*ExecResult // command pattern -> result
+	execHistory []string               // commands that were executed
+}
+
+func newMockCommandExecutor() *mockCommandExecutor {
+	return &mockCommandExecutor{
+		commands:    make(map[string]*ExecResult),
+		execHistory: []string{},
+	}
+}
+
+func (m *mockCommandExecutor) Exec(cmd string) (*ExecResult, error) {
+	m.execHistory = append(m.execHistory, cmd)
+
+	// Check for exact match first
+	if result, ok := m.commands[cmd]; ok {
+		return result, nil
+	}
+
+	// Check for prefix match
+	for pattern, result := range m.commands {
+		if strings.Contains(cmd, pattern) {
+			return result, nil
+		}
+	}
+
+	// Default: return success with empty output
+	return &ExecResult{Stdout: "", Stderr: "", ExitCode: 0}, nil
+}
+
+func (m *mockCommandExecutor) setResult(cmdPattern string, stdout string, exitCode int) {
+	m.commands[cmdPattern] = &ExecResult{
+		Stdout:   stdout,
+		Stderr:   "",
+		ExitCode: exitCode,
+	}
+}
+
+func (m *mockCommandExecutor) setError(cmdPattern string, stderr string, exitCode int) {
+	m.commands[cmdPattern] = &ExecResult{
+		Stdout:   "",
+		Stderr:   stderr,
+		ExitCode: exitCode,
+	}
+}
+
+// Test constants are correctly defined
+func TestCNIConstants(t *testing.T) {
+	assert.Equal(t, "/etc/cni/net.d/10-containerd-net.conflist", CNIConfigPath)
+	assert.Equal(t, "/etc/cni/net.d", CNIConfigDir)
+	assert.Contains(t, BridgeNetworkingServices, "openbao")
+	assert.Contains(t, BridgeNetworkingServices, "foundry-zot")
+}
+
+func TestCNIConfigContent(t *testing.T) {
+	// Verify CNI config contains expected fields
+	assert.Contains(t, CNIConfigContent, "containerd-net")
+	assert.Contains(t, CNIConfigContent, "bridge")
+	assert.Contains(t, CNIConfigContent, "portmap")
+	assert.Contains(t, CNIConfigContent, "firewall")
+	assert.Contains(t, CNIConfigContent, "tuning")
+	assert.Contains(t, CNIConfigContent, "10.88.0.0/16")
+}
+
+func TestIsCNIConfigValid_Valid(t *testing.T) {
+	mock := newMockCommandExecutor()
+
+	// Config file exists
+	mock.setResult(fmt.Sprintf("test -f %s && echo 'ok'", CNIConfigPath), "ok", 0)
+	// Config contains expected content
+	mock.setResult("grep -q 'containerd-net'", "ok", 0)
+
+	valid := isCNIConfigValid(mock)
+	assert.True(t, valid)
+}
+
+func TestIsCNIConfigValid_Missing(t *testing.T) {
+	mock := newMockCommandExecutor()
+
+	// Config file doesn't exist
+	mock.setResult(fmt.Sprintf("test -f %s && echo 'ok'", CNIConfigPath), "", 1)
+
+	valid := isCNIConfigValid(mock)
+	assert.False(t, valid)
+}
+
+func TestIsCNIConfigValid_InvalidContent(t *testing.T) {
+	mock := newMockCommandExecutor()
+
+	// Config file exists
+	mock.setResult(fmt.Sprintf("test -f %s && echo 'ok'", CNIConfigPath), "ok", 0)
+	// But doesn't contain expected content
+	mock.setError("grep -q 'containerd-net'", "", 1)
+
+	valid := isCNIConfigValid(mock)
+	assert.False(t, valid)
+}
+
+func TestInstallCNIConfig_Success(t *testing.T) {
+	mock := newMockCommandExecutor()
+
+	// All commands succeed
+	mock.setResult(fmt.Sprintf("sudo mkdir -p %s", CNIConfigDir), "", 0)
+	mock.setResult("sudo tee", "", 0)
+
+	err := installCNIConfig(mock)
+	assert.NoError(t, err)
+
+	// Verify commands were called
+	assert.GreaterOrEqual(t, len(mock.execHistory), 2)
+}
+
+func TestInstallCNIConfig_MkdirFails(t *testing.T) {
+	mock := newMockCommandExecutor()
+
+	// mkdir fails
+	mock.setError(fmt.Sprintf("sudo mkdir -p %s", CNIConfigDir), "permission denied", 1)
+
+	err := installCNIConfig(mock)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create CNI config directory")
+}
+
+func TestEnsureCNIConfig_AlreadyExists(t *testing.T) {
+	mock := newMockCommandExecutor()
+
+	// Config exists and is valid
+	mock.setResult(fmt.Sprintf("test -f %s && echo 'ok'", CNIConfigPath), "ok", 0)
+	mock.setResult("grep -q 'containerd-net'", "ok", 0)
+
+	created, err := EnsureCNIConfig(mock)
+	require.NoError(t, err)
+	assert.False(t, created, "should not create config when it already exists")
+}
+
+func TestEnsureCNIConfig_CreatesNew(t *testing.T) {
+	mock := newMockCommandExecutor()
+
+	// Config doesn't exist
+	mock.setResult(fmt.Sprintf("test -f %s && echo 'ok'", CNIConfigPath), "", 1)
+	// mkdir and tee succeed
+	mock.setResult(fmt.Sprintf("sudo mkdir -p %s", CNIConfigDir), "", 0)
+	mock.setResult("sudo tee", "", 0)
+
+	created, err := EnsureCNIConfig(mock)
+	require.NoError(t, err)
+	assert.True(t, created, "should create config when it doesn't exist")
+}
+
+func TestDetectRuntimeInstallation_NerdctlComplete(t *testing.T) {
+	mock := newMockCommandExecutor()
+
+	// docker command exists
+	mock.setResult("which docker", "/usr/local/bin/docker", 0)
+	// docker version shows nerdctl
+	mock.setResult("docker version 2>&1", "nerdctl version 1.7.2", 0)
+	// CNI plugins installed
+	mock.setResult("test -f /opt/cni/bin/bridge && echo 'ok'", "ok", 0)
+	// CNI config valid
+	mock.setResult(fmt.Sprintf("test -f %s && echo 'ok'", CNIConfigPath), "ok", 0)
+	mock.setResult("grep -q 'containerd-net'", "ok", 0)
+
+	runtimeType := DetectRuntimeInstallation(mock)
+	assert.Equal(t, RuntimeNerdctl, runtimeType)
+}
+
+func TestDetectRuntimeInstallation_NerdctlIncompleteMissingConfig(t *testing.T) {
+	mock := newMockCommandExecutor()
+
+	// docker command exists
+	mock.setResult("which docker", "/usr/local/bin/docker", 0)
+	// docker version shows nerdctl
+	mock.setResult("docker version 2>&1", "nerdctl version 1.7.2", 0)
+	// CNI plugins installed
+	mock.setResult("test -f /opt/cni/bin/bridge && echo 'ok'", "ok", 0)
+	// CNI config missing
+	mock.setResult(fmt.Sprintf("test -f %s && echo 'ok'", CNIConfigPath), "", 1)
+
+	runtimeType := DetectRuntimeInstallation(mock)
+	assert.Equal(t, RuntimeNerdctlIncomplete, runtimeType)
+}
+
+func TestDetectRuntimeInstallation_NerdctlIncompleteMissingPlugins(t *testing.T) {
+	mock := newMockCommandExecutor()
+
+	// docker command exists
+	mock.setResult("which docker", "/usr/local/bin/docker", 0)
+	// docker version shows nerdctl
+	mock.setResult("docker version 2>&1", "nerdctl version 1.7.2", 0)
+	// CNI plugins missing
+	mock.setResult("test -f /opt/cni/bin/bridge && echo 'ok'", "", 1)
+
+	runtimeType := DetectRuntimeInstallation(mock)
+	assert.Equal(t, RuntimeNerdctlIncomplete, runtimeType)
+}
+
+func TestDetectRuntimeInstallation_Docker(t *testing.T) {
+	mock := newMockCommandExecutor()
+
+	// docker command exists
+	mock.setResult("which docker", "/usr/bin/docker", 0)
+	// docker version shows Docker Engine
+	mock.setResult("docker version 2>&1", "Docker Engine - Community\nVersion: 24.0.0\ndocker.com", 0)
+
+	runtimeType := DetectRuntimeInstallation(mock)
+	assert.Equal(t, RuntimeDocker, runtimeType)
+}
+
+func TestDetectRuntimeInstallation_None(t *testing.T) {
+	mock := newMockCommandExecutor()
+
+	// docker command doesn't exist
+	mock.setResult("which docker", "", 1)
+
+	runtimeType := DetectRuntimeInstallation(mock)
+	assert.Equal(t, RuntimeNone, runtimeType)
+}


### PR DESCRIPTION
If you need to use a private or insecure (or both) container registry, it needs to be added to the config for k3s and k3s needs to be restarted. This gives us that capability.