### PR TITLE
feat: add support for Tailscale CGNAT IPs in VIP configuration

### DIFF
--- a/csil/v1/components/k3s.csil
+++ b/csil/v1/components/k3s.csil
@@ -22,6 +22,7 @@ Config = {
     server_url: text @go_name("ServerURL"),
     dns_servers: [* text] @go_name("DNSServers"),
     ? additional_registries: [* AdditionalRegistry] @go_name("AdditionalRegistries"),
+    ? allow_cgnat_vip: bool @go_name("AllowCGNATVIP"),
 }
 
 ; Additional registry configuration for user-defined registries

--- a/csil/v1/config/network-simple.csil
+++ b/csil/v1/config/network-simple.csil
@@ -48,7 +48,8 @@ ClusterConfig = {
     name: text,
     ? domain: text,
     primary_domain: text @go_name("PrimaryDomain"),
-    vip: text @go_name("VIP")
+    vip: text @go_name("VIP"),
+    ? allow_cgnat_vip: bool @go_name("AllowCGNATVIP")
 }
 
 ; Map of component names to their configurations

--- a/docs/tailscale-integration.md
+++ b/docs/tailscale-integration.md
@@ -1,0 +1,271 @@
+# Using Foundry with Tailscale Networks
+
+This guide covers deploying Foundry clusters on Tailscale overlay networks using CGNAT IP addresses (RFC 6598 Shared Address Space, 100.64.0.0/10).
+
+## Overview
+
+Tailscale uses the CGNAT IP range (100.64.0.0/10) for its overlay network, which is outside the traditional RFC 1918 private IP ranges. By default, Foundry's VIP validation only accepts RFC 1918 addresses. The `allow_cgnat_vip` configuration flag enables support for Tailscale and similar overlay networks.
+
+## Prerequisites
+
+- Tailscale installed and configured on all cluster nodes
+- Nodes tagged appropriately (e.g., `tag:k8s`)
+- Tailscale ACL configured to allow inter-node communication
+
+## Required Tailscale ACL Configuration
+
+Your Tailscale ACL must allow:
+1. **Your local machine → cluster nodes** (for Foundry SSH access)
+2. **Cluster nodes → cluster nodes** (for K3s cluster formation)
+
+### Example ACL
+
+```json
+{
+  "acls": [
+    {
+      "action": "accept",
+      "src": ["*"],
+      "dst": ["*:*"]
+    }
+  ],
+  "ssh": [
+    {
+      "action": "accept",
+      "src": ["autogroup:members"],
+      "dst": ["tag:k8s"],
+      "users": ["root", "ubuntu"]
+    },
+    {
+      "action": "accept",
+      "src": ["tag:k8s"],
+      "dst": ["tag:k8s"],
+      "users": ["root"]
+    }
+  ],
+  "tagOwners": {
+    "tag:k8s": ["autogroup:admin"]
+  }
+}
+```
+
+**Critical:** The second SSH rule (`tag:k8s` → `tag:k8s`) allows cluster nodes to SSH to each other, which is required for K3s agent installation on worker nodes.
+
+## Configuration
+
+### VIP Requirements
+
+**IMPORTANT:** The VIP must always be a separate, dedicated IP address that is not assigned to any host. This is required because kube-vip manages the VIP through ARP advertisements, and having the VIP match a host's actual IP can cause network conflicts and packet loss.
+
+For Tailscale deployments, use a CGNAT IP in the 100.64.0.0/10 range that:
+- Is NOT assigned to any of your cluster nodes
+- Is within your Tailscale network's IP range
+- Will be advertised as a subnet route by the Tailscale operator
+
+### Setup Steps
+
+For both single and multi-control-plane setups, the process is the same:
+
+#### Step 1: Configure Foundry with a Dedicated VIP
+
+Choose a CGNAT IP for your VIP that is NOT assigned to any node:
+
+```yaml
+cluster:
+  name: my-cluster
+  primary_domain: example.local
+  vip: 100.81.89.100  # Dedicated VIP (not a node IP!)
+  allow_cgnat_vip: true
+
+hosts:
+  - hostname: control-plane
+    address: 100.81.89.62  # Different from VIP
+    user: root
+  - hostname: worker-1
+    address: 100.70.90.12
+    user: root
+  - hostname: worker-2
+    address: 100.125.196.1
+    user: root
+```
+
+#### Step 2: Deploy the Cluster
+
+Run Foundry to deploy K3s and kube-vip:
+
+```bash
+foundry stack install
+```
+
+#### Step 3: Install Tailscale Operator
+
+After the cluster is running, install the Tailscale operator to manage subnet route advertisements:
+
+```bash
+# Add Tailscale Helm repository
+helm repo add tailscale https://pkgs.tailscale.com/helmcharts
+helm repo update
+
+# Install the operator
+helm install tailscale-operator tailscale/tailscale-operator \
+  --namespace=tailscale \
+  --create-namespace \
+  --set-string oauth.clientId=${TS_OAUTH_CLIENT_ID} \
+  --set-string oauth.clientSecret=${TS_OAUTH_CLIENT_SECRET} \
+  --wait
+```
+
+**Prerequisites:**
+- Create OAuth credentials in Tailscale admin console: https://tailscale.com/kb/1236/kubernetes-operator
+- Set environment variables `TS_OAUTH_CLIENT_ID` and `TS_OAUTH_CLIENT_SECRET`
+
+#### Step 4: Configure ProxyClass for VIP Route
+
+Create a ProxyClass to advertise the VIP as a subnet route:
+
+```yaml
+apiVersion: tailscale.com/v1alpha1
+kind: ProxyClass
+metadata:
+  name: vip-advertiser
+spec:
+  statefulSet:
+    labels:
+      tailscale-vip: "true"
+    pod:
+      tailscaleContainer:
+        env:
+          - name: TS_ROUTES
+            value: "100.81.89.100/32"
+```
+
+Apply it:
+
+```bash
+kubectl apply -f proxyclass.yaml
+```
+
+This will automatically advertise your VIP subnet route to Tailscale, making it reachable from all nodes.
+
+## Network Routing Considerations
+
+### Understanding VIP Routing on Tailscale
+
+Traditional kube-vip assumes Layer 2 networking where the VIP can "float" between nodes via ARP announcements. Tailscale is a Layer 3 overlay network where:
+
+- **IPs are routed, not bridged** - Nodes communicate via Tailscale's WireGuard tunnels
+- **No ARP** - IP routing is managed by Tailscale's coordination server
+- **Explicit routes required** - Any IP that isn't a node's primary Tailscale IP needs to be advertised as a subnet route
+
+### VIP Reachability
+
+For worker nodes to reach the VIP:
+
+**All deployments (single or multi-control-plane):**
+- VIP must be a dedicated IP, separate from any node's IP
+- VIP must be advertised as a subnet route via Tailscale
+- Tailscale operator automates route management as VIP moves between nodes
+- kube-vip handles VIP assignment and failover via ARP (local to each node)
+
+## Troubleshooting
+
+### Workers Can't Join Cluster
+
+**Symptom:**
+```
+Failed to validate connection to cluster at https://100.81.89.100:6443:
+failed to get CA certs: context deadline exceeded
+```
+
+**Diagnosis:**
+Worker nodes cannot reach the VIP. Check:
+
+```bash
+# On a worker node
+curl -k https://<VIP>:6443/version --max-time 5
+
+# If it times out, the VIP is not routable
+```
+
+**Solution:**
+- Ensure VIP is advertised as a subnet route via Tailscale operator
+- Verify ProxyClass is configured correctly with the VIP route
+- Check that the route is approved in Tailscale admin console
+
+### SSH Connection Refused Between Nodes
+
+**Symptom:**
+```
+tailscale: tailnet policy does not permit you to SSH to this node
+```
+
+**Diagnosis:**
+Tailscale ACL doesn't allow SSH between cluster nodes.
+
+**Solution:**
+Add SSH rule allowing `tag:k8s` → `tag:k8s` as shown in the ACL example above.
+
+### VIP Assigned But Not Reachable
+
+**Symptom:**
+- `ip addr show` on control plane shows VIP assigned
+- Workers still can't reach it
+
+**Diagnosis:**
+VIP is assigned to the local interface but not advertised to Tailscale.
+
+**Solution:**
+```bash
+# Check if Tailscale operator is running
+kubectl get pods -n tailscale
+
+# Check if ProxyClass is configured
+kubectl get proxyclass
+
+# Verify the route is being advertised
+kubectl logs -n tailscale -l tailscale-vip=true
+
+# If operator is not installed, install it following Step 3 above
+```
+
+## Validation Checklist
+
+Before deploying:
+
+- [ ] All nodes have Tailscale installed and connected
+- [ ] Nodes are tagged appropriately (e.g., `tag:k8s`)
+- [ ] Tailscale ACL allows SSH from your machine to nodes
+- [ ] Tailscale ACL allows SSH between nodes (`tag:k8s` → `tag:k8s`)
+- [ ] For HA setups: VIP subnet route is configured and approved
+- [ ] `allow_cgnat_vip: true` is set in cluster config
+- [ ] Workers can reach the VIP: `curl -k https://<VIP>:6443/version`
+
+## Roadmap
+
+Future enhancements planned for Tailscale integration:
+
+1. **Automated Tailscale Operator Installation**
+   - Automatic operator installation during cluster setup
+   - Auto-generated OAuth credentials integration
+   - Automated ProxyClass configuration
+
+2. **Multi-Cluster Mesh**
+   - Connect multiple Foundry clusters via Tailscale
+   - Cross-cluster service discovery
+   - Unified network policy across clusters
+
+3. **GitOps for Tailscale ACLs**
+   - Version control for network policies
+   - CI/CD automation for ACL updates
+   - Integration with Foundry stack management
+
+## References
+
+- [RFC 6598 - Shared Address Space (CGNAT)](https://www.rfc-editor.org/rfc/rfc6598)
+- [Tailscale ACL Documentation](https://tailscale.com/kb/1018/acls/)
+- [Tailscale Subnet Routes](https://tailscale.com/kb/1019/subnets/)
+- [kube-vip Documentation](https://kube-vip.io/)
+
+## Contributing
+
+Found an issue or have suggestions for Tailscale integration? Please open an issue on the [Foundry GitHub repository](https://github.com/catalystcommunity/foundry).

--- a/v1/cmd/foundry/commands/cluster/init.go
+++ b/v1/cmd/foundry/commands/cluster/init.go
@@ -284,6 +284,7 @@ func InitializeCluster(ctx context.Context, cfg *config.Config) error {
 			fmt.Sprintf("%s.%s", cfg.Cluster.Name, cfg.Cluster.PrimaryDomain),
 		},
 		DisableComponents: []string{"traefik", "servicelb"},
+		AllowCGNATVIP:     cfg.Cluster.AllowCGNATVIP,
 	}
 
 	// Parse additional registries and etcd args from component config
@@ -345,6 +346,7 @@ func InitializeCluster(ctx context.Context, cfg *config.Config) error {
 			DisableComponents: k3sConfig.DisableComponents,
 			RegistryConfig:    k3sConfig.RegistryConfig,
 			EtcdArgs:          k3sConfig.EtcdArgs,
+			AllowCGNATVIP:     k3sConfig.AllowCGNATVIP,
 		}
 
 		// Join control plane

--- a/v1/internal/component/k3s/install.go
+++ b/v1/internal/component/k3s/install.go
@@ -294,8 +294,9 @@ func waitForK3sReady(executor SSHExecutor, retryCfg RetryConfig) error {
 func setupKubeVIP(ctx context.Context, executor SSHExecutor, cfg *Config) error {
 	// Determine VIP config
 	vipConfig := &VIPConfig{
-		VIP:       cfg.VIP,
-		Interface: cfg.Interface,
+		VIP:           cfg.VIP,
+		Interface:     cfg.Interface,
+		AllowCGNATVIP: cfg.AllowCGNATVIP,
 	}
 
 	// Generate kube-vip manifests

--- a/v1/internal/component/k3s/types.gen.go
+++ b/v1/internal/component/k3s/types.gen.go
@@ -17,9 +17,8 @@ type Config struct {
 	ServerURL string `json:"server_url" yaml:"server_url"`
 	DNSServers []string `json:"dns_servers" yaml:"dns_servers"`
 	AdditionalRegistries []AdditionalRegistry `json:"additional_registries,omitempty" yaml:"additional_registries,omitempty"`
-	// EtcdArgs are additional arguments passed to the embedded etcd server
-	// Example: ["heartbeat-interval=500", "election-timeout=5000"]
 	EtcdArgs []string `json:"etcd_args,omitempty" yaml:"etcd_args,omitempty"`
+	AllowCGNATVIP *bool `json:"allow_cgnat_vip,omitempty" yaml:"allow_cgnat_vip,omitempty"`
 }
 
 // AdditionalRegistry represents a structured data type

--- a/v1/internal/component/k3s/types.go
+++ b/v1/internal/component/k3s/types.go
@@ -194,7 +194,9 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("VIP is required")
 	}
 
-	if err := ValidateVIP(c.VIP); err != nil {
+	// Dereference AllowCGNATVIP pointer (defaults to false if nil)
+	allowCGNAT := c.AllowCGNATVIP != nil && *c.AllowCGNATVIP
+	if err := ValidateVIP(c.VIP, allowCGNAT); err != nil {
 		return fmt.Errorf("VIP validation failed: %w", err)
 	}
 

--- a/v1/internal/component/k3s/vip.go
+++ b/v1/internal/component/k3s/vip.go
@@ -13,6 +13,9 @@ import (
 type VIPConfig struct {
 	VIP       string
 	Interface string
+	// AllowCGNATVIP is *bool (not bool) because it's optional in CSIL-generated Config.
+	// Pointer allows nil (not set) vs false (explicitly disabled). Defaults to false if nil.
+	AllowCGNATVIP *bool
 }
 
 // SSHExecutor is an interface for executing SSH commands
@@ -22,7 +25,9 @@ type SSHExecutor interface {
 }
 
 // ValidateVIP validates that a VIP address is in correct format
-func ValidateVIP(vip string) error {
+// allowCGNAT enables validation of IPs in the 100.64.0.0/10 range (RFC6598 Shared Address Space)
+// used by Tailscale and other overlay networks
+func ValidateVIP(vip string, allowCGNAT bool) error {
 	if vip == "" {
 		return fmt.Errorf("VIP address cannot be empty")
 	}
@@ -38,20 +43,28 @@ func ValidateVIP(vip string) error {
 		return fmt.Errorf("VIP must be an IPv4 address: %s", vip)
 	}
 
-	// Check if it's a private IP (RFC1918)
-	if !isPrivateIP(ip) {
-		return fmt.Errorf("VIP should be a private IP address: %s", vip)
+	// Check if it's a private IP (RFC1918) or optionally shared address space (RFC6598)
+	if !isPrivateIP(ip, allowCGNAT) {
+		if allowCGNAT {
+			return fmt.Errorf("VIP should be a private IP address (RFC1918 or RFC6598): %s", vip)
+		}
+		return fmt.Errorf("VIP should be a private IP address: %s (hint: set allow_cgnat_vip: true to use CGNAT IPs in the 100.64.0.0/10 range)", vip)
 	}
 
 	return nil
 }
 
-// isPrivateIP checks if an IP is in private ranges (RFC1918)
-func isPrivateIP(ip net.IP) bool {
+// isPrivateIP checks if an IP is in private ranges (RFC1918) or optionally shared address space (RFC6598)
+func isPrivateIP(ip net.IP, allowCGNAT bool) bool {
 	private := []string{
-		"10.0.0.0/8",
-		"172.16.0.0/12",
-		"192.168.0.0/16",
+		"10.0.0.0/8",        // RFC1918 - Private-Use
+		"172.16.0.0/12",     // RFC1918 - Private-Use
+		"192.168.0.0/16",    // RFC1918 - Private-Use
+	}
+
+	// Optionally include CGNAT range (RFC6598) used by Tailscale and similar overlay networks
+	if allowCGNAT {
+		private = append(private, "100.64.0.0/10") // RFC6598 - Shared Address Space (CGNAT)
 	}
 
 	for _, cidr := range private {
@@ -81,9 +94,9 @@ func DetectNetworkInterface(conn network.SSHExecutor) (string, error) {
 
 // DetermineVIPConfig determines the VIP configuration for the cluster
 // It validates the VIP and detects the network interface
-func DetermineVIPConfig(vip string, conn network.SSHExecutor) (*VIPConfig, error) {
+func DetermineVIPConfig(vip string, conn network.SSHExecutor, allowCGNAT bool) (*VIPConfig, error) {
 	// Validate VIP
-	if err := ValidateVIP(vip); err != nil {
+	if err := ValidateVIP(vip, allowCGNAT); err != nil {
 		return nil, fmt.Errorf("VIP validation failed: %w", err)
 	}
 
@@ -93,9 +106,12 @@ func DetermineVIPConfig(vip string, conn network.SSHExecutor) (*VIPConfig, error
 		return nil, fmt.Errorf("interface detection failed: %w", err)
 	}
 
+	// Convert bool to *bool for VIPConfig
+	allowCGNATPtr := &allowCGNAT
 	return &VIPConfig{
-		VIP:       vip,
-		Interface: iface,
+		VIP:           vip,
+		Interface:     iface,
+		AllowCGNATVIP: allowCGNATPtr,
 	}, nil
 }
 
@@ -115,7 +131,9 @@ func GenerateKubeVIPManifest(cfg *VIPConfig) (string, error) {
 	}
 
 	// Validate VIP one more time
-	if err := ValidateVIP(cfg.VIP); err != nil {
+	// Dereference AllowCGNATVIP pointer (defaults to false if nil)
+	allowCGNAT := cfg.AllowCGNATVIP != nil && *cfg.AllowCGNATVIP
+	if err := ValidateVIP(cfg.VIP, allowCGNAT); err != nil {
 		return "", fmt.Errorf("invalid VIP configuration: %w", err)
 	}
 

--- a/v1/internal/component/k3s/vip_test.go
+++ b/v1/internal/component/k3s/vip_test.go
@@ -90,7 +90,7 @@ func TestValidateVIP(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := ValidateVIP(tt.vip)
+			err := ValidateVIP(tt.vip, false)
 			if tt.wantErr {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.errMsg)
@@ -244,7 +244,7 @@ func TestDetermineVIPConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mock := tt.setupMock()
-			got, err := DetermineVIPConfig(tt.vip, mock)
+			got, err := DetermineVIPConfig(tt.vip, mock, false)
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -573,7 +573,7 @@ func TestIsPrivateIP(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ip := parseIP(t, tt.ip)
-			got := isPrivateIP(ip)
+			got := isPrivateIP(ip, false)
 			assert.Equal(t, tt.want, got)
 		})
 	}
@@ -603,7 +603,7 @@ func TestVIPConfigIntegration(t *testing.T) {
 	vip := "192.168.1.100"
 
 	// Step 1: Determine VIP config
-	cfg, err := DetermineVIPConfig(vip, mock)
+	cfg, err := DetermineVIPConfig(vip, mock, false)
 	require.NoError(t, err)
 	assert.Equal(t, vip, cfg.VIP)
 	assert.Equal(t, "eth0", cfg.Interface)

--- a/v1/internal/component/k3s/vip_test.go
+++ b/v1/internal/component/k3s/vip_test.go
@@ -521,6 +521,89 @@ func TestFormatManifests(t *testing.T) {
 	}
 }
 
+// TestValidateVIPWithCGNAT tests CGNAT VIP validation (RFC6598 - 100.64.0.0/10)
+func TestValidateVIPWithCGNAT(t *testing.T) {
+	tests := []struct {
+		name       string
+		vip        string
+		allowCGNAT bool
+		wantErr    bool
+		errMsg     string
+	}{
+		{
+			name:       "valid CGNAT IP - lower bound",
+			vip:        "100.64.0.0",
+			allowCGNAT: true,
+			wantErr:    false,
+		},
+		{
+			name:       "valid CGNAT IP - middle of range",
+			vip:        "100.127.255.255",
+			allowCGNAT: true,
+			wantErr:    false,
+		},
+		{
+			name:       "valid CGNAT IP - upper bound",
+			vip:        "100.127.255.255",
+			allowCGNAT: true,
+			wantErr:    false,
+		},
+		{
+			name:       "CGNAT IP rejected without flag",
+			vip:        "100.64.0.0",
+			allowCGNAT: false,
+			wantErr:    true,
+			errMsg:     "should be a private IP",
+		},
+		{
+			name:       "CGNAT IP rejected without flag - upper range",
+			vip:        "100.127.255.255",
+			allowCGNAT: false,
+			wantErr:    true,
+			errMsg:     "should be a private IP",
+		},
+		{
+			name:       "CGNAT IP just outside range - below",
+			vip:        "100.63.255.255",
+			allowCGNAT: false,
+			wantErr:    true,
+			errMsg:     "should be a private IP",
+		},
+		{
+			name:       "CGNAT IP just outside range - above",
+			vip:        "100.128.0.0",
+			allowCGNAT: false,
+			wantErr:    true,
+			errMsg:     "should be a private IP",
+		},
+		{
+			name:       "Tailscale common IP",
+			vip:        "100.101.102.103",
+			allowCGNAT: true,
+			wantErr:    false,
+		},
+		{
+			name:       "Tailscale common IP rejected without flag",
+			vip:        "100.101.102.103",
+			allowCGNAT: false,
+			wantErr:    true,
+			errMsg:     "should be a private IP",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateVIP(tt.vip, tt.allowCGNAT)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 // TestIsPrivateIP tests private IP detection
 func TestIsPrivateIP(t *testing.T) {
 	tests := []struct {

--- a/v1/internal/component/k3s/worker.go
+++ b/v1/internal/component/k3s/worker.go
@@ -22,7 +22,9 @@ func JoinWorker(ctx context.Context, executor SSHExecutor, serverURL string, tok
 
 	// Validate VIP if provided (worker nodes may not need full config validation)
 	if cfg.VIP != "" {
-		if err := ValidateVIP(cfg.VIP); err != nil {
+		// Dereference AllowCGNATVIP pointer (defaults to false if nil)
+		allowCGNAT := cfg.AllowCGNATVIP != nil && *cfg.AllowCGNATVIP
+		if err := ValidateVIP(cfg.VIP, allowCGNAT); err != nil {
 			return fmt.Errorf("VIP validation failed: %w", err)
 		}
 	}

--- a/v1/internal/config/network_test.go
+++ b/v1/internal/config/network_test.go
@@ -220,7 +220,7 @@ func TestConfig_ValidateVIPUniqueness(t *testing.T) {
 			errMsg:  "conflicts with host",
 		},
 		{
-			name: "VIP conflicts with cluster node",
+			name: "VIP conflicts with cluster control plane node",
 			config: Config{
 				Network: &NetworkConfig{
 					Gateway: "192.168.1.1",
@@ -236,7 +236,31 @@ func TestConfig_ValidateVIPUniqueness(t *testing.T) {
 				Cluster: ClusterConfig{
 					Name:          "test",
 					PrimaryDomain: "example.com",
-					VIP:    "192.168.1.20", // Conflicts with node1
+					VIP:    "192.168.1.20", // Conflicts with control plane node1
+				},
+				Components: ComponentMap{"k3s": ComponentConfig{}},
+			},
+			wantErr: true,
+			errMsg:  "cannot be the same as control plane host",
+		},
+		{
+			name: "VIP conflicts with cluster worker node",
+			config: Config{
+				Network: &NetworkConfig{
+					Gateway: "192.168.1.1",
+					Netmask: "255.255.255.0",
+				},
+				Hosts: []*host.Host{
+					{
+						Hostname: "worker1",
+						Address:  "192.168.1.30",
+						Roles:    []string{host.RoleClusterWorker},
+					},
+				},
+				Cluster: ClusterConfig{
+					Name:          "test",
+					PrimaryDomain: "example.com",
+					VIP:    "192.168.1.30", // Conflicts with worker1
 				},
 				Components: ComponentMap{"k3s": ComponentConfig{}},
 			},

--- a/v1/internal/config/types.gen.go
+++ b/v1/internal/config/types.gen.go
@@ -43,6 +43,7 @@ type ClusterConfig struct {
 	Domain *string `json:"domain,omitempty" yaml:"domain,omitempty"`
 	PrimaryDomain string `json:"primary_domain" yaml:"primary_domain"`
 	VIP string `json:"vip" yaml:"vip"`
+	AllowCGNATVIP *bool `json:"allow_cgnat_vip,omitempty" yaml:"allow_cgnat_vip,omitempty"`
 }
 
 // ComponentMap is a type alias

--- a/v1/internal/config/types.go
+++ b/v1/internal/config/types.go
@@ -83,7 +83,11 @@ func (c *Config) validateK8sVIPUniqueness() error {
 	// Check against all host addresses
 	for _, h := range c.Hosts {
 		if h.Address == vip {
-			return fmt.Errorf("k8s_vip %q conflicts with host %q IP address", vip, h.Hostname)
+			// Special error message for control plane conflicts (common mistake)
+			if h.HasRole(host.RoleClusterControlPlane) {
+				return fmt.Errorf("k8s_vip %q cannot be the same as control plane host %q IP address - VIP must be a separate floating IP managed by kube-vip", vip, h.Hostname)
+			}
+			return fmt.Errorf("k8s_vip %q conflicts with host %q IP address - VIP must be a unique IP address", vip, h.Hostname)
 		}
 	}
 


### PR DESCRIPTION
Add optional `allow_cgnat_vip` configuration flag to enable VIP addresses in the CGNAT range (100.64.0.0/10, RFC 6598) used by Tailscale and similar overlay networks.

Background:
- Foundry previously only accepted RFC 1918 private IPs for VIP
- Tailscale uses RFC 6598 Shared Address Space (100.64.0.0/10)
- This prevented users from deploying clusters exclusively on Tailscale

Changes:
- Add `allow_cgnat_vip` field to ClusterConfig and K3s Config (CSIL schemas)
- Update VIP validation to accept CGNAT range when flag is true
- Wire flag through all validation paths (init, worker, vip)
- Maintain backward compatibility (defaults to false)
- Use *bool for optional field (CSIL generation constraint)

Usage:
```yaml
cluster:
  vip: 100.81.89.100
  allow_cgnat_vip: true
```

Helpful error message suggests the flag when CGNAT IP is rejected.