### PR TITLE
fix: expand prometheus default size and give room for WAL

### DIFF
--- a/v1/cmd/foundry/commands/stack/install.go
+++ b/v1/cmd/foundry/commands/stack/install.go
@@ -1358,21 +1358,49 @@ func getSeaweedFSCredentials(cfg *config.Config) (accessKey, secretKey string) {
 func buildPrometheusConfig(cfg *config.Config) component.ComponentConfig {
 	ingressHost := fmt.Sprintf("prometheus.%s", cfg.Cluster.PrimaryDomain)
 
+	// Defaults that can be overridden from components.prometheus in config YAML
+	retentionDays := 15
+	retentionSize := "160GB"
+	storageSize := "200Gi"
+	storageClass := "longhorn"
+
+	if cfg.Components != nil {
+		if compCfg, exists := cfg.Components["prometheus"]; exists && compCfg.Config != nil {
+			if v, ok := compCfg.Config["retention_days"]; ok {
+				switch val := v.(type) {
+				case int:
+					retentionDays = val
+				case float64:
+					retentionDays = int(val)
+				}
+			}
+			if v, ok := compCfg.Config["retention_size"].(string); ok {
+				retentionSize = v
+			}
+			if v, ok := compCfg.Config["storage_size"].(string); ok {
+				storageSize = v
+			}
+			if v, ok := compCfg.Config["storage_class"].(string); ok {
+				storageClass = v
+			}
+		}
+	}
+
 	// Default Helm values for kube-prometheus-stack (YAML format for readability)
 	defaultValuesYAML := fmt.Sprintf(`
 prometheus:
   prometheusSpec:
-    retention: 15d
+    retention: %dd
     scrapeInterval: 30s
     storageSpec:
       volumeClaimTemplate:
         spec:
-          storageClassName: longhorn
+          storageClassName: %s
           accessModes:
             - ReadWriteOnce
           resources:
             requests:
-              storage: 10Gi
+              storage: %s
     # ServiceMonitor discovery - discover all ServiceMonitors
     serviceMonitorSelectorNilUsesHelmValues: false
     serviceMonitorSelector: {}
@@ -1416,15 +1444,16 @@ prometheusOperator:
     requests:
       cpu: 100m
       memory: 128Mi
-`, ingressHost, ingressHost)
+`, retentionDays, storageClass, storageSize, ingressHost, ingressHost)
 
 	defaultValues := parseYAMLValues(defaultValuesYAML)
 
 	componentConfig := component.ComponentConfig{
 		"namespace":       "monitoring",
-		"retention_days":  15,
-		"storage_size":    "10Gi",
-		"storage_class":   "longhorn",
+		"retention_days":  retentionDays,
+		"retention_size":  retentionSize,
+		"storage_size":    storageSize,
+		"storage_class":   storageClass,
 		"ingress_enabled": true,
 		"ingress_host":    ingressHost,
 	}

--- a/v1/internal/component/prometheus/install_test.go
+++ b/v1/internal/component/prometheus/install_test.go
@@ -147,7 +147,7 @@ func TestBuildHelmValues_Default(t *testing.T) {
 	require.True(t, ok)
 
 	assert.Equal(t, "15d", prometheusSpec["retention"])
-	assert.Equal(t, "10GB", prometheusSpec["retentionSize"]) // Must end with 'B' per Prometheus CRD spec
+	assert.Equal(t, "160GB", prometheusSpec["retentionSize"]) // Must end with 'B' per Prometheus CRD spec
 	assert.Equal(t, "30s", prometheusSpec["scrapeInterval"])
 
 	// Check Grafana is disabled

--- a/v1/internal/component/prometheus/types.go
+++ b/v1/internal/component/prometheus/types.go
@@ -3,6 +3,9 @@ package prometheus
 import (
 	"context"
 	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/catalystcommunity/foundry/v1/internal/component"
 	"github.com/catalystcommunity/foundry/v1/internal/helm"
@@ -180,9 +183,9 @@ func DefaultConfig() *Config {
 		Version:                 "67.4.0", // kube-prometheus-stack chart version
 		Namespace:               "monitoring",
 		RetentionDays:           15,
-		RetentionSize:           "10GB", // Must end with 'B' per Prometheus CRD spec
-		StorageClass:            "",     // Use cluster default
-		StorageSize:             "20Gi",
+		RetentionSize:           "160GB", // Must end with 'B' per Prometheus CRD spec; ~80% of StorageSize for WAL headroom
+		StorageClass:            "",      // Use cluster default
+		StorageSize:             "200Gi",
 		AlertmanagerEnabled:     true,
 		GrafanaEnabled:          false, // We deploy Grafana separately
 		NodeExporterEnabled:     true,
@@ -311,11 +314,44 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("retention_days must be at least 1")
 	}
 
+	if c.StorageSize != "" {
+		if _, err := resource.ParseQuantity(c.StorageSize); err != nil {
+			return fmt.Errorf("invalid storage_size %q: %w (use Kubernetes quantity format, e.g. 200Gi)", c.StorageSize, err)
+		}
+	}
+
+	if c.RetentionSize != "" {
+		if err := validatePrometheusSize(c.RetentionSize); err != nil {
+			return err
+		}
+	}
+
 	if c.IngressEnabled && c.IngressHost == "" {
 		return fmt.Errorf("ingress_host is required when ingress is enabled")
 	}
 
 	return nil
+}
+
+// validatePrometheusSize checks that a size string uses Prometheus's expected
+// format: a number followed by a unit suffix ending in B (e.g. "160GB").
+func validatePrometheusSize(size string) error {
+	validUnits := []string{"EB", "PB", "TB", "GB", "MB", "KB", "B"}
+	for _, unit := range validUnits {
+		if strings.HasSuffix(size, unit) {
+			numPart := strings.TrimSuffix(size, unit)
+			if numPart == "" {
+				return fmt.Errorf("invalid retention_size %q: missing numeric value", size)
+			}
+			for _, ch := range numPart {
+				if ch < '0' || ch > '9' {
+					return fmt.Errorf("invalid retention_size %q: non-numeric prefix", size)
+				}
+			}
+			return nil
+		}
+	}
+	return fmt.Errorf("invalid retention_size %q: must end with a byte unit (B, KB, MB, GB, TB, PB, EB)", size)
 }
 
 // GetPrometheusEndpoint returns the Prometheus endpoint URL for internal cluster access

--- a/v1/internal/component/prometheus/types_test.go
+++ b/v1/internal/component/prometheus/types_test.go
@@ -17,9 +17,9 @@ func TestDefaultConfig(t *testing.T) {
 	assert.Equal(t, "67.4.0", config.Version)
 	assert.Equal(t, "monitoring", config.Namespace)
 	assert.Equal(t, 15, config.RetentionDays)
-	assert.Equal(t, "10GB", config.RetentionSize) // Must end with 'B' per Prometheus CRD spec
+	assert.Equal(t, "160GB", config.RetentionSize) // Must end with 'B' per Prometheus CRD spec
 	assert.Equal(t, "", config.StorageClass)
-	assert.Equal(t, "20Gi", config.StorageSize)
+	assert.Equal(t, "200Gi", config.StorageSize)
 	assert.True(t, config.AlertmanagerEnabled)
 	assert.False(t, config.GrafanaEnabled)
 	assert.True(t, config.NodeExporterEnabled)
@@ -45,7 +45,7 @@ func TestParseConfig_CustomValues(t *testing.T) {
 		"version":                   "66.0.0",
 		"namespace":                 "custom-monitoring",
 		"retention_days":            30,
-		"retention_size":            "50Gi",
+		"retention_size":            "50GB",
 		"storage_class":             "fast-storage",
 		"storage_size":              "100Gi",
 		"alertmanager_enabled":      false,
@@ -63,7 +63,7 @@ func TestParseConfig_CustomValues(t *testing.T) {
 	assert.Equal(t, "66.0.0", config.Version)
 	assert.Equal(t, "custom-monitoring", config.Namespace)
 	assert.Equal(t, 30, config.RetentionDays)
-	assert.Equal(t, "50Gi", config.RetentionSize)
+	assert.Equal(t, "50GB", config.RetentionSize)
 	assert.Equal(t, "fast-storage", config.StorageClass)
 	assert.Equal(t, "100Gi", config.StorageSize)
 	assert.False(t, config.AlertmanagerEnabled)
@@ -133,6 +133,66 @@ func TestValidate_IngressEnabled_WithHost(t *testing.T) {
 
 	err := config.Validate()
 	assert.NoError(t, err)
+}
+
+func TestValidate_InvalidStorageSize(t *testing.T) {
+	config := &Config{
+		RetentionDays: 15,
+		StorageSize:   "notasize",
+	}
+
+	err := config.Validate()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid storage_size")
+}
+
+func TestValidate_ValidStorageSize(t *testing.T) {
+	config := &Config{
+		RetentionDays: 15,
+		StorageSize:   "200Gi",
+	}
+
+	err := config.Validate()
+	assert.NoError(t, err)
+}
+
+func TestValidate_InvalidRetentionSize(t *testing.T) {
+	tests := []struct {
+		name string
+		size string
+	}{
+		{"no unit", "160"},
+		{"kubernetes format", "160Gi"},
+		{"empty number", "GB"},
+		{"non-numeric prefix", "abcGB"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := &Config{
+				RetentionDays: 15,
+				RetentionSize: tt.size,
+			}
+			err := config.Validate()
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "retention_size")
+		})
+	}
+}
+
+func TestValidate_ValidRetentionSize(t *testing.T) {
+	tests := []string{"160GB", "1TB", "500MB", "100KB", "1024B", "1PB", "1EB"}
+
+	for _, size := range tests {
+		t.Run(size, func(t *testing.T) {
+			config := &Config{
+				RetentionDays: 15,
+				RetentionSize: size,
+			}
+			err := config.Validate()
+			assert.NoError(t, err)
+		})
+	}
 }
 
 func TestGetPrometheusEndpoint(t *testing.T) {


### PR DESCRIPTION
This is still almost no storage, but might be beyond older hardware laying around. Guess we'll see. Regardless, it's something that can be set in an override in yaml.