### PR TITLE
feat: add CustomDomain config to Tailscale component

### DIFF
--- a/csil/v1/components/k3s.csil
+++ b/csil/v1/components/k3s.csil
@@ -22,6 +22,7 @@ Config = {
     server_url: text @go_name("ServerURL"),
     dns_servers: [* text] @go_name("DNSServers"),
     ? additional_registries: [* AdditionalRegistry] @go_name("AdditionalRegistries"),
+? etcd_args: [* text] @go_name("EtcdArgs"),
     ? allow_cgnat_vip: bool @go_name("AllowCGNATVIP"),
 }
 

--- a/docs/tailscale-integration.md
+++ b/docs/tailscale-integration.md
@@ -53,6 +53,7 @@ Your Tailscale ACL must allow:
 
 ## Configuration
 
+<<<<<<< HEAD
 ### VIP Requirements
 
 **IMPORTANT:** The VIP must always be a separate, dedicated IP address that is not assigned to any host. This is required because kube-vip manages the VIP through ARP advertisements, and having the VIP match a host's actual IP can cause network conflicts and packet loss.
@@ -69,17 +70,30 @@ For both single and multi-control-plane setups, the process is the same:
 #### Step 1: Configure Foundry with a Dedicated VIP
 
 Choose a CGNAT IP for your VIP that is NOT assigned to any node:
+=======
+### Single Control Plane Setup
+
+For single control plane deployments, use a dedicated VIP address that is routable via Tailscale:
+>>>>>>> 9edde40 (feat: add CGNAT VIP support and Tailscale integration)
 
 ```yaml
 cluster:
   name: my-cluster
   primary_domain: example.local
+<<<<<<< HEAD
   vip: 100.81.89.100  # Dedicated VIP (not a node IP!)
+=======
+  vip: 100.81.89.100  # Dedicated VIP (not assigned to any host)
+>>>>>>> 9edde40 (feat: add CGNAT VIP support and Tailscale integration)
   allow_cgnat_vip: true
 
 hosts:
   - hostname: control-plane
+<<<<<<< HEAD
     address: 100.81.89.62  # Different from VIP
+=======
+    address: 100.81.89.62  # Control plane's Tailscale IP
+>>>>>>> 9edde40 (feat: add CGNAT VIP support and Tailscale integration)
     user: root
   - hostname: worker-1
     address: 100.70.90.12
@@ -89,6 +103,7 @@ hosts:
     user: root
 ```
 
+<<<<<<< HEAD
 #### Step 2: Deploy the Cluster
 
 Run Foundry to deploy K3s and kube-vip:
@@ -146,6 +161,50 @@ kubectl apply -f proxyclass.yaml
 ```
 
 This will automatically advertise your VIP subnet route to Tailscale, making it reachable from all nodes.
+=======
+**Important:** The VIP must be different from any host's IP address. You must advertise the VIP as a subnet route from the control plane:
+
+```bash
+# On the control plane node
+tailscale up --advertise-routes=100.81.89.100/32
+```
+
+Then approve the route in the Tailscale admin console.
+
+### High Availability (Multi-Control-Plane) Setup
+
+For HA setups with multiple control planes, you need to make the VIP routable via Tailscale:
+
+#### Option 1: Tailscale Subnet Routes
+
+Advertise the VIP as a subnet route from the active control plane:
+
+```bash
+# On the control plane node
+tailscale up --advertise-routes=100.81.89.100/32
+```
+
+Then approve the route in the Tailscale admin console.
+
+```yaml
+cluster:
+  name: my-cluster
+  primary_domain: example.local
+  vip: 100.81.89.100  # Dedicated VIP
+  allow_cgnat_vip: true
+```
+
+**Note:** kube-vip will manage the VIP assignment, but you need to ensure the route is advertised from whichever node currently holds the VIP.
+
+#### Option 2: Tailscale Operator (Recommended for HA)
+
+The Tailscale Operator integration will be available in a future Foundry release. This will provide:
+- Automatic operator installation on control planes
+- Automated VIP subnet route management
+- Support for cross-pod network policies via Tailscale ACLs
+
+For now, use Option 1 (Subnet Routes) for HA setups.
+>>>>>>> 9edde40 (feat: add CGNAT VIP support and Tailscale integration)
 
 ## Network Routing Considerations
 
@@ -161,11 +220,21 @@ Traditional kube-vip assumes Layer 2 networking where the VIP can "float" betwee
 
 For worker nodes to reach the VIP:
 
+<<<<<<< HEAD
 **All deployments (single or multi-control-plane):**
 - VIP must be a dedicated IP, separate from any node's IP
 - VIP must be advertised as a subnet route via Tailscale
 - Tailscale operator automates route management as VIP moves between nodes
 - kube-vip handles VIP assignment and failover via ARP (local to each node)
+=======
+**Single control plane:**
+- VIP = control plane IP → Always routable (it's the node's primary IP)
+
+**Multiple control planes:**
+- VIP = dedicated IP → Must be advertised as subnet route
+- Route must be updated when VIP moves between control planes
+- Tailscale operator can automate this
+>>>>>>> 9edde40 (feat: add CGNAT VIP support and Tailscale integration)
 
 ## Troubleshooting
 
@@ -188,9 +257,14 @@ curl -k https://<VIP>:6443/version --max-time 5
 ```
 
 **Solution:**
+<<<<<<< HEAD
 - Ensure VIP is advertised as a subnet route via Tailscale operator
 - Verify ProxyClass is configured correctly with the VIP route
 - Check that the route is approved in Tailscale admin console
+=======
+- Single control plane: Advertise VIP as subnet route from control plane
+- Multi control plane: Advertise VIP as subnet route from active control plane
+>>>>>>> 9edde40 (feat: add CGNAT VIP support and Tailscale integration)
 
 ### SSH Connection Refused Between Nodes
 
@@ -216,6 +290,7 @@ VIP is assigned to the local interface but not advertised to Tailscale.
 
 **Solution:**
 ```bash
+<<<<<<< HEAD
 # Check if Tailscale operator is running
 kubectl get pods -n tailscale
 
@@ -226,6 +301,12 @@ kubectl get proxyclass
 kubectl logs -n tailscale -l tailscale-vip=true
 
 # If operator is not installed, install it following Step 3 above
+=======
+# On control plane
+tailscale up --advertise-routes=<VIP>/32
+
+# Then approve in Tailscale admin console
+>>>>>>> 9edde40 (feat: add CGNAT VIP support and Tailscale integration)
 ```
 
 ## Validation Checklist
@@ -244,10 +325,17 @@ Before deploying:
 
 Future enhancements planned for Tailscale integration:
 
+<<<<<<< HEAD
 1. **Automated Tailscale Operator Installation**
    - Automatic operator installation during cluster setup
    - Auto-generated OAuth credentials integration
    - Automated ProxyClass configuration
+=======
+1. **Tailscale Operator Integration**
+   - Automatic operator installation on control planes
+   - Automated VIP subnet route management
+   - Support for cross-pod network policies via Tailscale ACLs
+>>>>>>> 9edde40 (feat: add CGNAT VIP support and Tailscale integration)
 
 2. **Multi-Cluster Mesh**
    - Connect multiple Foundry clusters via Tailscale

--- a/docs/tailscale-integration.md
+++ b/docs/tailscale-integration.md
@@ -27,45 +27,25 @@ The automated operator integration requires OAuth credentials:
 
 1. **Create OAuth Client**:
    - Go to: https://login.tailscale.com/admin/settings/oauth
-   - Click "+ Credential" → "OAuth client"
-   - Name/Description: `foundry-cluster-<name>` or `k8s-operator`
-   - **Scopes**: Choose one of:
-     - **Recommended**: Select "all" for full operator functionality
-     - **Minimum Required**:
-       - `devices:write` - Create and manage devices
-       - `routes:write` - Advertise subnet routes
-   - Click "Generate client"
-   - **Important**: Copy both Client ID and Client Secret immediately
-   - **Note**: Client Secret is shown only once and is single-use (regenerate if lost)
+   - Click "Generate OAuth Client"
+   - Name: `foundry-cluster-<name>`
+   - Scopes (minimum required):
+     - `devices:write` - Create and manage devices
+     - `routes:write` - Advertise subnet routes
+   - Save the `client_id` (starts with `tskey-client-`)
+   - Save the `client_secret` (starts with `tskey-secret-`)
 
 2. **Store Credentials Securely**:
 
-   **Option A: `.foundryvars` File (Recommended for Local Development)**
-   ```bash
-   # Create or edit ~/.foundryvars
-   cat >> ~/.foundryvars <<EOF
-   foundry-core/tailscale:client_id=<YOUR_CLIENT_ID>
-   foundry-core/tailscale:client_secret=<YOUR_CLIENT_SECRET>
-   EOF
-
-   # Secure the file
-   chmod 600 ~/.foundryvars
-   ```
-
-   **Option B: OpenBAO (Recommended for Production)**
+   **Option A: OpenBAO (Recommended for Production)**
    ```bash
    foundry openbao write foundry-core/tailscale \
      client_id="<YOUR_CLIENT_ID>" \
      client_secret="<YOUR_CLIENT_SECRET>"
    ```
 
-   **Option C: Literal Values (Not Recommended)**
-   - Use credentials directly in configuration (insecure, avoid for production)
-
-   **Secret Resolution Order**: Foundry checks in this order:
-   1. Environment variables (`FOUNDRY_SECRET_FOUNDRY_CORE_TAILSCALE_CLIENT_ID`)
-   2. `.foundryvars` file (`~/.foundryvars`)
-   3. OpenBAO KV store (`foundry-core/tailscale`)
+   **Option B: Literal Values (Development/Testing Only)**
+   - Use credentials directly in configuration (not recommended for production)
 
 ## Required Tailscale ACL Configuration
 
@@ -101,22 +81,12 @@ Your Tailscale ACL must allow:
   ],
   "tagOwners": {
     "tag:k8s": ["autogroup:admin"],
-    "tag:k8s-operator": ["autogroup:admin"],  // Required for Tailscale operator
     "tag:k8s-foundry": ["autogroup:admin"]
   }
 }
 ```
 
 **Critical:** The second SSH rule (`tag:k8s` → `tag:k8s`) allows cluster nodes to SSH to each other, which is required for K3s agent installation on worker nodes.
-
-**Required Tags:**
-- `tag:k8s-operator` - Used by the Tailscale operator itself (auto-assigned by operator)
-- Any custom tags specified in your `components.tailscale.tags` configuration must be defined in `tagOwners`
-
-**Important**: If you add tags to the ACL after the operator has started, you must restart the operator pod to pick up the ACL changes:
-```bash
-kubectl delete pod -n tailscale <operator-pod-name>
-```
 
 ## Configuration
 
@@ -219,38 +189,6 @@ The operator automatically advertises your cluster VIP as a Tailscale subnet rou
 Routes advertised:
 - Cluster VIP (e.g., `100.81.89.100/32`)
 - Any additional routes in `advertise_routes` config
-
-## Installation Order for Multi-Node with Tailscale
-
-When deploying a multi-node cluster with `use_tailscale: true` and a CGNAT VIP, follow this sequence:
-
-1. **Install control plane only** (set `k8s_installed: false` in setup_state)
-2. **Install Tailscale operator** - This advertises the VIP route
-3. **Set `k8s_installed: false`** in setup_state to trigger worker installation
-4. **Run `foundry stack install`** again to join workers
-
-**Why this order is needed:**
-- Workers need to reach the VIP to join the cluster
-- The VIP route is only advertised after Tailscale operator starts
-- Setting `k8s_installed: true` tells Foundry to skip K3s installation
-- Setting it back to `false` allows workers to join on the next run
-
-**Example workflow:**
-```bash
-# 1. Initial install (control plane only)
-foundry stack install --config stack.yaml
-# Result: k8s_installed: true
-
-# 2. Tailscale operator deploys automatically
-
-# 3. Edit stack.yaml: change k8s_installed: true → false
-
-# 4. Install workers
-foundry stack install --config stack.yaml
-# Workers can now reach VIP via Tailscale
-```
-
-**Note:** This workflow will be automated in a future release (see [Issue #17](https://github.com/catalystcommunity/foundry/issues/17)).
 
 ## Verification
 

--- a/docs/tailscale-integration.md
+++ b/docs/tailscale-integration.md
@@ -1,22 +1,78 @@
 # Using Foundry with Tailscale Networks
 
-This guide covers deploying Foundry clusters on Tailscale overlay networks using CGNAT IP addresses (RFC 6598 Shared Address Space, 100.64.0.0/10).
+This guide covers deploying Foundry clusters on Tailscale overlay networks using CGNAT IP addresses (RFC 6598 Shared Address Space, 100.64.0.0/10) with automated Tailscale operator integration.
 
 ## Overview
 
-Tailscale uses the CGNAT IP range (100.64.0.0/10) for its overlay network, which is outside the traditional RFC 1918 private IP ranges. By default, Foundry's VIP validation only accepts RFC 1918 addresses. The `allow_cgnat_vip` configuration flag enables support for Tailscale and similar overlay networks.
+Tailscale uses the CGNAT IP range (100.64.0.0/10) for its overlay network, which is outside the traditional RFC 1918 private IP ranges. Foundry provides two levels of Tailscale support:
+
+1. **Basic CGNAT Support** (`allow_cgnat_vip: true`) - Enables using Tailscale IPs for cluster VIPs
+2. **Automated Operator Integration** (`use_tailscale: true`) - Automatically deploys and configures the Tailscale operator
 
 ## Prerequisites
 
+### For Basic CGNAT Support
 - Tailscale installed and configured on all cluster nodes
 - Nodes tagged appropriately (e.g., `tag:k8s`)
 - Tailscale ACL configured to allow inter-node communication
+
+### For Automated Operator Integration
+- OAuth client credentials from Tailscale (see Setup section)
+- OpenBAO configured for secret storage (recommended)
+- All basic prerequisites above
+
+## Tailscale OAuth Client Setup
+
+The automated operator integration requires OAuth credentials:
+
+1. **Create OAuth Client**:
+   - Go to: https://login.tailscale.com/admin/settings/oauth
+   - Click "+ Credential" → "OAuth client"
+   - Name/Description: `foundry-cluster-<name>` or `k8s-operator`
+   - **Scopes**: Choose one of:
+     - **Recommended**: Select "all" for full operator functionality
+     - **Minimum Required**:
+       - `devices:write` - Create and manage devices
+       - `routes:write` - Advertise subnet routes
+   - Click "Generate client"
+   - **Important**: Copy both Client ID and Client Secret immediately
+   - **Note**: Client Secret is shown only once and is single-use (regenerate if lost)
+
+2. **Store Credentials Securely**:
+
+   **Option A: `.foundryvars` File (Recommended for Local Development)**
+   ```bash
+   # Create or edit ~/.foundryvars
+   cat >> ~/.foundryvars <<EOF
+   foundry-core/tailscale:client_id=<YOUR_CLIENT_ID>
+   foundry-core/tailscale:client_secret=<YOUR_CLIENT_SECRET>
+   EOF
+
+   # Secure the file
+   chmod 600 ~/.foundryvars
+   ```
+
+   **Option B: OpenBAO (Recommended for Production)**
+   ```bash
+   foundry openbao write foundry-core/tailscale \
+     client_id="<YOUR_CLIENT_ID>" \
+     client_secret="<YOUR_CLIENT_SECRET>"
+   ```
+
+   **Option C: Literal Values (Not Recommended)**
+   - Use credentials directly in configuration (insecure, avoid for production)
+
+   **Secret Resolution Order**: Foundry checks in this order:
+   1. Environment variables (`FOUNDRY_SECRET_FOUNDRY_CORE_TAILSCALE_CLIENT_ID`)
+   2. `.foundryvars` file (`~/.foundryvars`)
+   3. OpenBAO KV store (`foundry-core/tailscale`)
 
 ## Required Tailscale ACL Configuration
 
 Your Tailscale ACL must allow:
 1. **Your local machine → cluster nodes** (for Foundry SSH access)
 2. **Cluster nodes → cluster nodes** (for K3s cluster formation)
+3. **Cluster pods → Tailscale network** (via operator)
 
 ### Example ACL
 
@@ -44,147 +100,54 @@ Your Tailscale ACL must allow:
     }
   ],
   "tagOwners": {
-    "tag:k8s": ["autogroup:admin"]
+    "tag:k8s": ["autogroup:admin"],
+    "tag:k8s-operator": ["autogroup:admin"],  // Required for Tailscale operator
+    "tag:k8s-foundry": ["autogroup:admin"]
   }
 }
 ```
 
 **Critical:** The second SSH rule (`tag:k8s` → `tag:k8s`) allows cluster nodes to SSH to each other, which is required for K3s agent installation on worker nodes.
 
+**Required Tags:**
+- `tag:k8s-operator` - Used by the Tailscale operator itself (auto-assigned by operator)
+- Any custom tags specified in your `components.tailscale.tags` configuration must be defined in `tagOwners`
+
+**Important**: If you add tags to the ACL after the operator has started, you must restart the operator pod to pick up the ACL changes:
+```bash
+kubectl delete pod -n tailscale <operator-pod-name>
+```
+
 ## Configuration
 
-<<<<<<< HEAD
-### VIP Requirements
+### Single Control Plane with Basic CGNAT Support
 
-**IMPORTANT:** The VIP must always be a separate, dedicated IP address that is not assigned to any host. This is required because kube-vip manages the VIP through ARP advertisements, and having the VIP match a host's actual IP can cause network conflicts and packet loss.
-
-For Tailscale deployments, use a CGNAT IP in the 100.64.0.0/10 range that:
-- Is NOT assigned to any of your cluster nodes
-- Is within your Tailscale network's IP range
-- Will be advertised as a subnet route by the Tailscale operator
-
-### Setup Steps
-
-For both single and multi-control-plane setups, the process is the same:
-
-#### Step 1: Configure Foundry with a Dedicated VIP
-
-Choose a CGNAT IP for your VIP that is NOT assigned to any node:
-=======
-### Single Control Plane Setup
-
-For single control plane deployments, use a dedicated VIP address that is routable via Tailscale:
->>>>>>> 9edde40 (feat: add CGNAT VIP support and Tailscale integration)
+For single control plane deployments without the operator:
 
 ```yaml
 cluster:
   name: my-cluster
   primary_domain: example.local
-<<<<<<< HEAD
-  vip: 100.81.89.100  # Dedicated VIP (not a node IP!)
-=======
-  vip: 100.81.89.100  # Dedicated VIP (not assigned to any host)
->>>>>>> 9edde40 (feat: add CGNAT VIP support and Tailscale integration)
+  vip: 100.81.89.62  # Control plane's Tailscale IP
   allow_cgnat_vip: true
 
 hosts:
   - hostname: control-plane
-<<<<<<< HEAD
-    address: 100.81.89.62  # Different from VIP
-=======
-    address: 100.81.89.62  # Control plane's Tailscale IP
->>>>>>> 9edde40 (feat: add CGNAT VIP support and Tailscale integration)
+    address: 100.81.89.62
     user: root
   - hostname: worker-1
     address: 100.70.90.12
     user: root
-  - hostname: worker-2
-    address: 100.125.196.1
-    user: root
 ```
 
-<<<<<<< HEAD
-#### Step 2: Deploy the Cluster
+**Why this works:**
+- Single control plane means no HA failover needed
+- VIP is just a stable endpoint for workers to connect to
+- Using the control plane's actual IP avoids routing complexity
 
-Run Foundry to deploy K3s and kube-vip:
+### High Availability with Automated Operator (Recommended)
 
-```bash
-foundry stack install
-```
-
-#### Step 3: Install Tailscale Operator
-
-After the cluster is running, install the Tailscale operator to manage subnet route advertisements:
-
-```bash
-# Add Tailscale Helm repository
-helm repo add tailscale https://pkgs.tailscale.com/helmcharts
-helm repo update
-
-# Install the operator
-helm install tailscale-operator tailscale/tailscale-operator \
-  --namespace=tailscale \
-  --create-namespace \
-  --set-string oauth.clientId=${TS_OAUTH_CLIENT_ID} \
-  --set-string oauth.clientSecret=${TS_OAUTH_CLIENT_SECRET} \
-  --wait
-```
-
-**Prerequisites:**
-- Create OAuth credentials in Tailscale admin console: https://tailscale.com/kb/1236/kubernetes-operator
-- Set environment variables `TS_OAUTH_CLIENT_ID` and `TS_OAUTH_CLIENT_SECRET`
-
-#### Step 4: Configure ProxyClass for VIP Route
-
-Create a ProxyClass to advertise the VIP as a subnet route:
-
-```yaml
-apiVersion: tailscale.com/v1alpha1
-kind: ProxyClass
-metadata:
-  name: vip-advertiser
-spec:
-  statefulSet:
-    labels:
-      tailscale-vip: "true"
-    pod:
-      tailscaleContainer:
-        env:
-          - name: TS_ROUTES
-            value: "100.81.89.100/32"
-```
-
-Apply it:
-
-```bash
-kubectl apply -f proxyclass.yaml
-```
-
-This will automatically advertise your VIP subnet route to Tailscale, making it reachable from all nodes.
-=======
-**Important:** The VIP must be different from any host's IP address. You must advertise the VIP as a subnet route from the control plane:
-
-```bash
-# On the control plane node
-tailscale up --advertise-routes=100.81.89.100/32
-```
-
-Then approve the route in the Tailscale admin console.
-
-### High Availability (Multi-Control-Plane) Setup
-
-For HA setups with multiple control planes, you need to make the VIP routable via Tailscale:
-
-#### Option 1: Tailscale Subnet Routes
-
-Advertise the VIP as a subnet route from the active control plane:
-
-```bash
-# On the control plane node
-tailscale up --advertise-routes=100.81.89.100/32
-```
-
-Then approve the route in the Tailscale admin console.
+For HA setups with automated Tailscale integration:
 
 ```yaml
 cluster:
@@ -192,19 +155,123 @@ cluster:
   primary_domain: example.local
   vip: 100.81.89.100  # Dedicated VIP
   allow_cgnat_vip: true
+  use_tailscale: true  # Enable automated operator
+
+components:
+  tailscale:
+    # OAuth credentials from OpenBAO
+    oauth_client_id: ${secret:foundry-core/tailscale:client_id}
+    oauth_client_secret: ${secret:foundry-core/tailscale:client_secret}
+
+    # Optional: Custom tags for ACL policies
+    tags:
+      - tag:k8s-foundry
+      - tag:production
+
+    # Optional: Additional routes to advertise
+    advertise_routes:
+      - 10.0.0.0/8
+
+hosts:
+  - hostname: control-1
+    address: 100.81.89.62
+    user: root
+  - hostname: control-2
+    address: 100.81.89.63
+    user: root
+  - hostname: worker-1
+    address: 100.70.90.12
+    user: root
 ```
 
-**Note:** kube-vip will manage the VIP assignment, but you need to ensure the route is advertised from whichever node currently holds the VIP.
+### Using Literal Credentials (Development Only)
 
-#### Option 2: Tailscale Operator (Recommended for HA)
+For development/testing without OpenBAO:
 
-The Tailscale Operator integration will be available in a future Foundry release. This will provide:
-- Automatic operator installation on control planes
-- Automated VIP subnet route management
-- Support for cross-pod network policies via Tailscale ACLs
+```yaml
+cluster:
+  name: dev-cluster
+  vip: 100.81.89.100
+  allow_cgnat_vip: true
+  use_tailscale: true
 
-For now, use Option 1 (Subnet Routes) for HA setups.
->>>>>>> 9edde40 (feat: add CGNAT VIP support and Tailscale integration)
+components:
+  tailscale:
+    # Direct credentials (NOT recommended for production)
+    oauth_client_id: tskey-client-abc123def456
+    oauth_client_secret: tskey-secret-xyz789abc123
+```
+
+## What Gets Deployed with `use_tailscale: true`
+
+When you enable automated operator integration, Foundry:
+
+1. **Creates Namespace**: `tailscale` namespace for operator resources
+2. **Installs Operator**: Deploys Tailscale operator via Helm
+3. **Configures Connector**: Creates Connector CRD to advertise VIP as subnet route
+4. **Enables Magic DNS**: Deploys DNSConfig CRD for Tailscale hostname resolution
+5. **Patches CoreDNS**: Configures CoreDNS to forward `.ts.net` queries to Tailscale DNS
+
+### Automatic VIP Route Advertisement
+
+The operator automatically advertises your cluster VIP as a Tailscale subnet route, eliminating the need for manual `tailscale up --advertise-routes` commands.
+
+Routes advertised:
+- Cluster VIP (e.g., `100.81.89.100/32`)
+- Any additional routes in `advertise_routes` config
+
+## Installation Order for Multi-Node with Tailscale
+
+When deploying a multi-node cluster with `use_tailscale: true` and a CGNAT VIP, follow this sequence:
+
+1. **Install control plane only** (set `k8s_installed: false` in setup_state)
+2. **Install Tailscale operator** - This advertises the VIP route
+3. **Set `k8s_installed: false`** in setup_state to trigger worker installation
+4. **Run `foundry stack install`** again to join workers
+
+**Why this order is needed:**
+- Workers need to reach the VIP to join the cluster
+- The VIP route is only advertised after Tailscale operator starts
+- Setting `k8s_installed: true` tells Foundry to skip K3s installation
+- Setting it back to `false` allows workers to join on the next run
+
+**Example workflow:**
+```bash
+# 1. Initial install (control plane only)
+foundry stack install --config stack.yaml
+# Result: k8s_installed: true
+
+# 2. Tailscale operator deploys automatically
+
+# 3. Edit stack.yaml: change k8s_installed: true → false
+
+# 4. Install workers
+foundry stack install --config stack.yaml
+# Workers can now reach VIP via Tailscale
+```
+
+**Note:** This workflow will be automated in a future release (see [Issue #17](https://github.com/catalystcommunity/foundry/issues/17)).
+
+## Verification
+
+After deployment, verify the Tailscale integration:
+
+```bash
+# Check operator pods
+kubectl get pods -n tailscale
+
+# Check Connector status (shows advertised routes)
+kubectl get connector -n tailscale -o yaml
+
+# Check DNSConfig
+kubectl get dnsconfig -n tailscale
+
+# Verify VIP is reachable from workers
+curl -k https://<VIP>:6443/version --max-time 5
+
+# Test Magic DNS from a pod
+kubectl run test --image=nicolaka/netshoot -it --rm -- nslookup mydevice.your-tailnet.ts.net
+```
 
 ## Network Routing Considerations
 
@@ -218,25 +285,93 @@ Traditional kube-vip assumes Layer 2 networking where the VIP can "float" betwee
 
 ### VIP Reachability
 
-For worker nodes to reach the VIP:
+**With automated operator (`use_tailscale: true`):**
+- Operator automatically advertises VIP via Connector CRD
+- Routes update dynamically as VIP moves between control planes
+- No manual intervention needed
 
-<<<<<<< HEAD
-**All deployments (single or multi-control-plane):**
-- VIP must be a dedicated IP, separate from any node's IP
-- VIP must be advertised as a subnet route via Tailscale
-- Tailscale operator automates route management as VIP moves between nodes
-- kube-vip handles VIP assignment and failover via ARP (local to each node)
-=======
-**Single control plane:**
-- VIP = control plane IP → Always routable (it's the node's primary IP)
-
-**Multiple control planes:**
-- VIP = dedicated IP → Must be advertised as subnet route
-- Route must be updated when VIP moves between control planes
-- Tailscale operator can automate this
->>>>>>> 9edde40 (feat: add CGNAT VIP support and Tailscale integration)
+**Without operator:**
+- Single control plane: VIP = control plane IP → Always routable
+- Multiple control planes: Must manually advertise VIP as subnet route
 
 ## Troubleshooting
+
+### Operator Not Starting
+
+**Symptom:**
+```bash
+kubectl get pods -n tailscale
+# Shows operator pod in CrashLoopBackOff
+```
+
+**Diagnosis:**
+Check operator logs:
+```bash
+kubectl logs -n tailscale -l app=tailscale-operator
+```
+
+**Common issues:**
+- Invalid OAuth credentials
+- OAuth client missing required scopes (`devices:write`, `routes:write`)
+- Network connectivity to Tailscale coordination server
+
+**Solution:**
+```bash
+# Verify credentials in OpenBAO
+foundry openbao read foundry-core/tailscale
+
+# Update if needed
+foundry openbao write foundry-core/tailscale \
+  client_id="<CORRECT_CLIENT_ID>" \
+  client_secret="<CORRECT_CLIENT_SECRET>"
+
+# Restart operator
+kubectl rollout restart deployment -n tailscale tailscale-operator
+```
+
+### VIP Not Advertised
+
+**Symptom:**
+Workers can't reach VIP after operator installation.
+
+**Diagnosis:**
+```bash
+# Check Connector status
+kubectl get connector -n tailscale foundry-vip-connector -o yaml
+
+# Look for status conditions
+```
+
+**Solution:**
+- Verify Connector created: `kubectl get connector -n tailscale`
+- Check operator logs: `kubectl logs -n tailscale -l app=tailscale-operator`
+- Ensure OAuth client has `routes:write` scope
+- Check Tailscale admin console for route approval requirements
+
+### DNS Resolution Not Working
+
+**Symptom:**
+Pods can't resolve `.ts.net` hostnames.
+
+**Diagnosis:**
+```bash
+# Check DNSConfig
+kubectl get dnsconfig -n tailscale ts-dns -o yaml
+
+# Check CoreDNS ConfigMap
+kubectl get configmap -n kube-system coredns -o yaml
+
+# Should have ts.net:53 forwarding block
+```
+
+**Solution:**
+```bash
+# Verify CoreDNS was patched
+kubectl get configmap -n kube-system coredns -o yaml | grep -A 4 "ts.net:53"
+
+# If missing, check installer logs
+foundry logs
+```
 
 ### Workers Can't Join Cluster
 
@@ -257,14 +392,10 @@ curl -k https://<VIP>:6443/version --max-time 5
 ```
 
 **Solution:**
-<<<<<<< HEAD
-- Ensure VIP is advertised as a subnet route via Tailscale operator
-- Verify ProxyClass is configured correctly with the VIP route
-- Check that the route is approved in Tailscale admin console
-=======
-- Single control plane: Advertise VIP as subnet route from control plane
-- Multi control plane: Advertise VIP as subnet route from active control plane
->>>>>>> 9edde40 (feat: add CGNAT VIP support and Tailscale integration)
+- Check operator is running: `kubectl get pods -n tailscale`
+- Verify Connector shows route advertised: `kubectl get connector -n tailscale -o yaml`
+- Check Tailscale admin console for pending route approvals
+- Ensure `use_tailscale: true` is set in cluster config
 
 ### SSH Connection Refused Between Nodes
 
@@ -279,36 +410,6 @@ Tailscale ACL doesn't allow SSH between cluster nodes.
 **Solution:**
 Add SSH rule allowing `tag:k8s` → `tag:k8s` as shown in the ACL example above.
 
-### VIP Assigned But Not Reachable
-
-**Symptom:**
-- `ip addr show` on control plane shows VIP assigned
-- Workers still can't reach it
-
-**Diagnosis:**
-VIP is assigned to the local interface but not advertised to Tailscale.
-
-**Solution:**
-```bash
-<<<<<<< HEAD
-# Check if Tailscale operator is running
-kubectl get pods -n tailscale
-
-# Check if ProxyClass is configured
-kubectl get proxyclass
-
-# Verify the route is being advertised
-kubectl logs -n tailscale -l tailscale-vip=true
-
-# If operator is not installed, install it following Step 3 above
-=======
-# On control plane
-tailscale up --advertise-routes=<VIP>/32
-
-# Then approve in Tailscale admin console
->>>>>>> 9edde40 (feat: add CGNAT VIP support and Tailscale integration)
-```
-
 ## Validation Checklist
 
 Before deploying:
@@ -317,41 +418,85 @@ Before deploying:
 - [ ] Nodes are tagged appropriately (e.g., `tag:k8s`)
 - [ ] Tailscale ACL allows SSH from your machine to nodes
 - [ ] Tailscale ACL allows SSH between nodes (`tag:k8s` → `tag:k8s`)
-- [ ] For HA setups: VIP subnet route is configured and approved
+- [ ] OAuth client created with required scopes
+- [ ] Credentials stored in OpenBAO or config
 - [ ] `allow_cgnat_vip: true` is set in cluster config
-- [ ] Workers can reach the VIP: `curl -k https://<VIP>:6443/version`
+- [ ] For automated integration: `use_tailscale: true` is set
+
+After deploying:
+
+- [ ] Operator pods running: `kubectl get pods -n tailscale`
+- [ ] Connector created: `kubectl get connector -n tailscale`
+- [ ] VIP route visible in Tailscale admin console
+- [ ] Workers can reach VIP: `curl -k https://<VIP>:6443/version`
+- [ ] DNS resolution works: `kubectl run test --image=nicolaka/netshoot -it --rm -- nslookup <device>.ts.net`
+
+## Advanced Configuration
+
+### Custom Operator Image
+
+```yaml
+components:
+  tailscale:
+    oauth_client_id: ${secret:foundry-core/tailscale:client_id}
+    oauth_client_secret: ${secret:foundry-core/tailscale:client_secret}
+    operator_image: custom-registry.com/tailscale-operator:v1.2.3
+```
+
+### Additional Subnet Routes
+
+Advertise additional routes beyond the VIP:
+
+```yaml
+components:
+  tailscale:
+    oauth_client_id: ${secret:foundry-core/tailscale:client_id}
+    oauth_client_secret: ${secret:foundry-core/tailscale:client_secret}
+    advertise_routes:
+      - 10.0.0.0/8      # Private network
+      - 172.16.0.0/12   # Another subnet
+```
+
+### Custom ACL Tags
+
+```yaml
+components:
+  tailscale:
+    oauth_client_id: ${secret:foundry-core/tailscale:client_id}
+    oauth_client_secret: ${secret:foundry-core/tailscale:client_secret}
+    tags:
+      - tag:k8s-foundry
+      - tag:production
+      - tag:us-west
+```
+
+Ensure these tags are defined in your Tailscale ACL `tagOwners`.
 
 ## Roadmap
 
 Future enhancements planned for Tailscale integration:
 
-<<<<<<< HEAD
-1. **Automated Tailscale Operator Installation**
-   - Automatic operator installation during cluster setup
-   - Auto-generated OAuth credentials integration
-   - Automated ProxyClass configuration
-=======
-1. **Tailscale Operator Integration**
-   - Automatic operator installation on control planes
-   - Automated VIP subnet route management
-   - Support for cross-pod network policies via Tailscale ACLs
->>>>>>> 9edde40 (feat: add CGNAT VIP support and Tailscale integration)
-
-2. **Multi-Cluster Mesh**
+1. **Multi-Cluster Mesh**
    - Connect multiple Foundry clusters via Tailscale
    - Cross-cluster service discovery
    - Unified network policy across clusters
 
-3. **GitOps for Tailscale ACLs**
+2. **GitOps for Tailscale ACLs**
    - Version control for network policies
    - CI/CD automation for ACL updates
    - Integration with Foundry stack management
+
+3. **Pod-to-Pod Tailscale Networking**
+   - Direct Tailscale connectivity for pods
+   - Per-pod Tailscale identities
+   - Fine-grained ACL policies at pod level
 
 ## References
 
 - [RFC 6598 - Shared Address Space (CGNAT)](https://www.rfc-editor.org/rfc/rfc6598)
 - [Tailscale ACL Documentation](https://tailscale.com/kb/1018/acls/)
 - [Tailscale Subnet Routes](https://tailscale.com/kb/1019/subnets/)
+- [Tailscale Kubernetes Operator](https://tailscale.com/kb/1236/kubernetes-operator/)
 - [kube-vip Documentation](https://kube-vip.io/)
 
 ## Contributing

--- a/v1/cmd/foundry/commands/component/install.go
+++ b/v1/cmd/foundry/commands/component/install.go
@@ -17,11 +17,11 @@ import (
 	"github.com/catalystcommunity/foundry/v1/internal/component/gatewayapi"
 	"github.com/catalystcommunity/foundry/v1/internal/component/grafana"
 	"github.com/catalystcommunity/foundry/v1/internal/component/loki"
-	"github.com/catalystcommunity/foundry/v1/internal/component/openbao"
-	"github.com/catalystcommunity/foundry/v1/internal/component/openbaoinjector"
-	"github.com/catalystcommunity/foundry/v1/internal/component/prometheus"
 	"github.com/catalystcommunity/foundry/v1/internal/component/seaweedfs"
+	"github.com/catalystcommunity/foundry/v1/internal/component/openbao"
+	"github.com/catalystcommunity/foundry/v1/internal/component/prometheus"
 	componentStorage "github.com/catalystcommunity/foundry/v1/internal/component/storage"
+	"github.com/catalystcommunity/foundry/v1/internal/component/tailscale"
 	"github.com/catalystcommunity/foundry/v1/internal/component/velero"
 	"github.com/catalystcommunity/foundry/v1/internal/config"
 	"github.com/catalystcommunity/foundry/v1/internal/helm"
@@ -102,17 +102,17 @@ Examples:
 
 // k8sComponents lists all components that are installed via kubeconfig (Helm/K8s)
 var k8sComponents = map[string]bool{
-	"gateway-api":      true,
-	"contour":          true,
-	"cert-manager":     true,
-	"storage":          true,
-	"seaweedfs":        true,
-	"prometheus":       true,
-	"loki":             true,
-	"grafana":          true,
-	"external-dns":     true,
-	"velero":           true,
-	"openbao-injector": true,
+	"gateway-api":   true,
+	"contour":       true,
+	"cert-manager":  true,
+	"storage":       true,
+	"seaweedfs":     true,
+	"prometheus":    true,
+	"loki":          true,
+	"grafana":       true,
+	"external-dns":  true,
+	"velero":        true,
+	"tailscale":     true,
 }
 
 func runInstall(ctx context.Context, cmd *cli.Command) error {
@@ -203,6 +203,12 @@ func installK8sComponent(ctx context.Context, cmd *cli.Command, name string, sta
 	k8sClient, err := k8s.NewClientFromKubeconfig(kubeconfigBytes)
 	if err != nil {
 		return fmt.Errorf("failed to create k8s client: %w", err)
+	}
+
+	// Build secret resolver for resolving secret references
+	resolver, resCtx, err := buildSecretResolver(stackConfig)
+	if err != nil {
+		return fmt.Errorf("failed to setup secret resolver: %w", err)
 	}
 
 	// Build component config
@@ -298,25 +304,78 @@ func installK8sComponent(ctx context.Context, cmd *cli.Command, name string, sta
 		cfg["s3_bucket"] = "velero"
 		cfg["s3_region"] = "us-east-1"
 		componentWithClients = velero.NewComponent(helmClient, k8sClient)
-	case "openbao-injector":
-		// Inject the OpenBao address so the webhook knows where to reach it
-		url, err := stackConfig.GetPrimaryOpenBAOURL()
-		if err != nil {
-			return fmt.Errorf("failed to get OpenBao address for injector: %w", err)
+	case "tailscale":
+		// Get VIP from stack config
+		vip := stackConfig.Cluster.VIP
+		if vip == "" {
+			return fmt.Errorf("cluster VIP is required for Tailscale installation")
 		}
-		cfg["external_vault_addr"] = url
+		cfg["vip"] = vip
 
-		// Create OpenBAO client for configuring Kubernetes auth
-		openbaoClient, err := createOpenBAOClient(stackConfig)
-		if err != nil {
-			return fmt.Errorf("failed to create OpenBAO client: %w", err)
+		// Get Tailscale config from stack.yaml components section
+		var tsComponentConfig *tailscale.Config
+		if tsConfig, ok := stackConfig.Components[name]; ok {
+			// Parse config from stack.yaml
+			tsComponentConfig = &tailscale.Config{}
+
+			// Resolve OAuth client ID
+			if clientID, ok := tsConfig.Config["oauth_client_id"].(string); ok {
+				// Check if it's a secret reference
+				secretRef, err := secrets.ParseSecretRef(clientID)
+				if err != nil {
+					return fmt.Errorf("failed to parse oauth_client_id: %w", err)
+				}
+				if secretRef != nil {
+					// Resolve from secret store
+					resolvedClientID, err := resolver.Resolve(resCtx, *secretRef)
+					if err != nil {
+						return fmt.Errorf("failed to resolve oauth_client_id: %w", err)
+					}
+					fmt.Printf("DEBUG: Resolved client_id from %s to %s\n", clientID, resolvedClientID[:10]+"...")
+					tsComponentConfig.OAuthClientID = &resolvedClientID
+				} else {
+					// Use literal value
+					tsComponentConfig.OAuthClientID = &clientID
+				}
+			}
+
+			// Resolve OAuth client secret
+			if clientSecret, ok := tsConfig.Config["oauth_client_secret"].(string); ok {
+				// Check if it's a secret reference
+				secretRef, err := secrets.ParseSecretRef(clientSecret)
+				if err != nil {
+					return fmt.Errorf("failed to parse oauth_client_secret: %w", err)
+				}
+				if secretRef != nil {
+					// Resolve from secret store
+					resolvedClientSecret, err := resolver.Resolve(resCtx, *secretRef)
+					if err != nil {
+						return fmt.Errorf("failed to resolve oauth_client_secret: %w", err)
+					}
+					tsComponentConfig.OAuthClientSecret = &resolvedClientSecret
+				} else {
+					// Use literal value
+					tsComponentConfig.OAuthClientSecret = &clientSecret
+				}
+			}
+
+			// Copy other config to cfg map
+			for k, v := range tsConfig.Config {
+				cfg[k] = v
+			}
 		}
-		componentWithClients = openbaoinjector.NewComponent(helmClient, k8sClient, openbaoClient)
+
+		// Create component with clients directly (like contour, prometheus, etc.)
+		componentWithClients = tailscale.NewComponentWithClients(tsComponentConfig, vip, helmClient, k8sClient)
 	default:
 		return fmt.Errorf("unknown kubernetes component: %s", name)
 	}
 
 	fmt.Printf("\nInstalling component: %s\n", name)
+
+	// Add clients to component config for components that need them
+	cfg["helm_client"] = helmClient
+	cfg["k8s_client"] = k8sClient
 
 	// Install the component
 	if err := componentWithClients.Install(ctx, cfg); err != nil {
@@ -364,10 +423,11 @@ func getDNSAPIKey(stackConfig *config.Config) (string, error) {
 		return "", err
 	}
 
-	openBAOAddr, err := stackConfig.GetPrimaryOpenBAOURL()
+	addr, err := stackConfig.GetPrimaryOpenBAOAddress()
 	if err != nil {
 		return "", err
 	}
+	openBAOAddr := fmt.Sprintf("http://%s:8200", addr)
 
 	keysPath := filepath.Join(configDir, "openbao-keys", stackConfig.Cluster.Name, "keys.json")
 	keysData, err := os.ReadFile(keysPath)
@@ -392,38 +452,6 @@ func getDNSAPIKey(stackConfig *config.Config) (string, error) {
 		return apiKey, nil
 	}
 	return "", fmt.Errorf("api_key not found in OpenBAO")
-}
-
-// createOpenBAOClient creates an OpenBAO client from stack config
-func createOpenBAOClient(stackConfig *config.Config) (*openbao.Client, error) {
-	configDir, err := config.GetConfigDir()
-	if err != nil {
-		return nil, err
-	}
-
-	openBAOAddr, err := stackConfig.GetPrimaryOpenBAOURL()
-	if err != nil {
-		return nil, err
-	}
-
-	keysPath := filepath.Join(configDir, "openbao-keys", stackConfig.Cluster.Name, "keys.json")
-	keysData, err := os.ReadFile(keysPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read OpenBAO keys file: %w", err)
-	}
-
-	var keys struct {
-		RootToken string `json:"root_token"`
-	}
-	if err := json.Unmarshal(keysData, &keys); err != nil {
-		return nil, fmt.Errorf("failed to parse OpenBAO keys file: %w", err)
-	}
-
-	if keys.RootToken == "" {
-		return nil, fmt.Errorf("root token not found in keys file")
-	}
-
-	return openbao.NewClient(openBAOAddr, keys.RootToken), nil
 }
 
 // installSSHComponent installs a container-based component via SSH
@@ -488,9 +516,10 @@ func installSSHComponent(ctx context.Context, cmd *cli.Command, name string, sta
 
 	// Add OpenBAO API URL (for OpenBAO component initialization)
 	if name == "openbao" {
-		url, err := stackConfig.GetPrimaryOpenBAOURL()
+		addr, err := stackConfig.GetPrimaryOpenBAOAddress()
 		if err == nil {
-			cfg["api_url"] = url
+			// Construct the API URL from the network config
+			cfg["api_url"] = fmt.Sprintf("http://%s:8200", addr)
 		}
 	}
 
@@ -755,20 +784,21 @@ func buildSecretResolver(cfg *config.Config) (*secrets.ChainResolver, *secrets.R
 	// Try to get OpenBAO address and token
 	var openBAOAddr, openBAOToken string
 
-	if addr, err := cfg.GetPrimaryOpenBAOURL(); err == nil {
-		openBAOAddr = addr
-	}
+	addr, err := cfg.GetPrimaryOpenBAOAddress()
+	if err == nil {
+		openBAOAddr = fmt.Sprintf("http://%s:8200", addr)
 
-	// Try to read OpenBAO token from keys file
-	configDir, errConfig := config.GetConfigDir()
-	if errConfig == nil {
-		keysPath := filepath.Join(configDir, "openbao-keys", cfg.Cluster.Name, "keys.json")
-		if keysData, errRead := os.ReadFile(keysPath); errRead == nil {
-			var keys struct {
-				RootToken string `json:"root_token"`
-			}
-			if errUnmarshal := json.Unmarshal(keysData, &keys); errUnmarshal == nil {
-				openBAOToken = keys.RootToken
+		// Try to read OpenBAO token from keys file
+		configDir, errConfig := config.GetConfigDir()
+		if errConfig == nil {
+			keysPath := filepath.Join(configDir, "openbao-keys", cfg.Cluster.Name, "keys.json")
+			if keysData, errRead := os.ReadFile(keysPath); errRead == nil {
+				var keys struct {
+					RootToken string `json:"root_token"`
+				}
+				if errUnmarshal := json.Unmarshal(keysData, &keys); errUnmarshal == nil {
+					openBAOToken = keys.RootToken
+				}
 			}
 		}
 	}
@@ -779,18 +809,41 @@ func buildSecretResolver(cfg *config.Config) (*secrets.ChainResolver, *secrets.R
 		Instance: "",
 	}
 
+	// Create FoundryVars resolver for ~/.foundryvars file
+	foundryVarsResolver, err := secrets.NewFoundryVarsResolverDefault()
+	if err != nil {
+		// Log warning but continue - foundryvars is optional
+		fmt.Printf("Warning: failed to load ~/.foundryvars: %v\n", err)
+	}
+
 	// If we have OpenBAO configured, add it to the resolver chain
 	if openBAOAddr != "" && openBAOToken != "" {
 		// Use foundry-core mount (where we enabled the KV v2 engine)
 		openBAOResolver, err := secrets.NewOpenBAOResolverWithMount(openBAOAddr, openBAOToken, "foundry-core")
 		if err != nil {
-			// Fall back to env-only if OpenBAO setup fails
+			// Fall back to env and foundryvars if OpenBAO setup fails
+			if foundryVarsResolver != nil {
+				resolver := secrets.NewChainResolver(
+					secrets.NewEnvResolver(),
+					foundryVarsResolver,
+				)
+				return resolver, resCtx, nil
+			}
 			resolver := secrets.NewChainResolver(
 				secrets.NewEnvResolver(),
 			)
 			return resolver, resCtx, nil
 		}
 
+		// Full chain: env -> foundryvars -> OpenBAO
+		if foundryVarsResolver != nil {
+			resolver := secrets.NewChainResolver(
+				secrets.NewEnvResolver(),
+				foundryVarsResolver,
+				openBAOResolver,
+			)
+			return resolver, resCtx, nil
+		}
 		resolver := secrets.NewChainResolver(
 			secrets.NewEnvResolver(),
 			openBAOResolver,
@@ -798,7 +851,16 @@ func buildSecretResolver(cfg *config.Config) (*secrets.ChainResolver, *secrets.R
 		return resolver, resCtx, nil
 	}
 
-	// OpenBAO not available, use env resolver only
+	// OpenBAO not available, use env and foundryvars
+	if foundryVarsResolver != nil {
+		resolver := secrets.NewChainResolver(
+			secrets.NewEnvResolver(),
+			foundryVarsResolver,
+		)
+		return resolver, resCtx, nil
+	}
+
+	// Fallback to env only
 	resolver := secrets.NewChainResolver(
 		secrets.NewEnvResolver(),
 	)
@@ -935,10 +997,11 @@ func ensureDNSAPIKey(stackConfig *config.Config) (string, error) {
 	}
 
 	// Get OpenBAO address from config
-	openBAOAddr, err := stackConfig.GetPrimaryOpenBAOURL()
+	addr, err := stackConfig.GetPrimaryOpenBAOAddress()
 	if err != nil {
 		return "", fmt.Errorf("OpenBAO host not configured: %w", err)
 	}
+	openBAOAddr := fmt.Sprintf("http://%s:8200", addr)
 
 	// Get OpenBAO token from keys file
 	keysPath := filepath.Join(configDir, "openbao-keys", stackConfig.Cluster.Name, "keys.json")
@@ -1100,12 +1163,12 @@ func buildExternalTargetsFromStackConfig(stackConfig *config.Config) []prometheu
 		return targets
 	}
 
-	// OpenBAO metrics at /v1/sys/metrics?format=prometheus
+	// OpenBAO metrics at /v1/sys/metrics?format=prometheus on port 8200
 	if stackConfig.SetupState.OpenBAOInstalled {
-		if addr, err := stackConfig.GetOpenBAOClientAddr(); err == nil {
+		if addr, err := stackConfig.GetPrimaryOpenBAOAddress(); err == nil {
 			targets = append(targets, prometheus.ExternalTarget{
 				Name:        "openbao",
-				Targets:     []string{addr},
+				Targets:     []string{fmt.Sprintf("%s:8200", addr)},
 				MetricsPath: "/v1/sys/metrics",
 				Params: map[string][]string{
 					"format": {"prometheus"},

--- a/v1/cmd/foundry/commands/component/install.go
+++ b/v1/cmd/foundry/commands/component/install.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/catalystcommunity/foundry/v1/internal/component"
 	"github.com/catalystcommunity/foundry/v1/internal/component/certmanager"
@@ -17,9 +18,9 @@ import (
 	"github.com/catalystcommunity/foundry/v1/internal/component/gatewayapi"
 	"github.com/catalystcommunity/foundry/v1/internal/component/grafana"
 	"github.com/catalystcommunity/foundry/v1/internal/component/loki"
-	"github.com/catalystcommunity/foundry/v1/internal/component/seaweedfs"
 	"github.com/catalystcommunity/foundry/v1/internal/component/openbao"
 	"github.com/catalystcommunity/foundry/v1/internal/component/prometheus"
+	"github.com/catalystcommunity/foundry/v1/internal/component/seaweedfs"
 	componentStorage "github.com/catalystcommunity/foundry/v1/internal/component/storage"
 	"github.com/catalystcommunity/foundry/v1/internal/component/tailscale"
 	"github.com/catalystcommunity/foundry/v1/internal/component/velero"
@@ -102,17 +103,17 @@ Examples:
 
 // k8sComponents lists all components that are installed via kubeconfig (Helm/K8s)
 var k8sComponents = map[string]bool{
-	"gateway-api":   true,
-	"contour":       true,
-	"cert-manager":  true,
-	"storage":       true,
-	"seaweedfs":     true,
-	"prometheus":    true,
-	"loki":          true,
-	"grafana":       true,
-	"external-dns":  true,
-	"velero":        true,
-	"tailscale":     true,
+	"gateway-api":  true,
+	"contour":      true,
+	"cert-manager": true,
+	"storage":      true,
+	"seaweedfs":    true,
+	"prometheus":   true,
+	"loki":         true,
+	"grafana":      true,
+	"external-dns": true,
+	"velero":       true,
+	"tailscale":    true,
 }
 
 func runInstall(ctx context.Context, cmd *cli.Command) error {
@@ -1110,6 +1111,12 @@ func isHelmReleaseInstalled(componentName string) bool {
 	}
 	defer helmClient.Close()
 
+	// Create K8s client for CR checks
+	k8sClient, err := k8s.NewClientFromKubeconfig(kubeconfigBytes)
+	if err != nil {
+		return false
+	}
+
 	// Map component names to release names and namespaces
 	releaseInfo := map[string]struct {
 		name      string
@@ -1118,8 +1125,8 @@ func isHelmReleaseInstalled(componentName string) bool {
 		"storage":      {"local-path-provisioner", "kube-system"},
 		"seaweedfs":    {"seaweedfs", "seaweedfs"},
 		"prometheus":   {"kube-prometheus-stack", "monitoring"},
-		"loki":         {"loki", "loki"},
-		"grafana":      {"grafana", "grafana"},
+		"loki":         {"loki", "monitoring"},
+		"grafana":      {"grafana", "monitoring"},
 		"external-dns": {"external-dns", "external-dns"},
 		"velero":       {"velero", "velero"},
 		"gateway-api":  {"gateway-api", "gateway-system"},
@@ -1138,6 +1145,11 @@ func isHelmReleaseInstalled(componentName string) bool {
 		return true
 	}
 
+	// Special case for prometheus - check for Prometheus CR (deployed via kube-prometheus-stack operator)
+	if componentName == "prometheus" {
+		return isPrometheusCRInstalled(k8sClient)
+	}
+
 	// Check for Helm release
 	releases, err := helmClient.List(context.Background(), info.namespace)
 	if err != nil {
@@ -1150,6 +1162,24 @@ func isHelmReleaseInstalled(componentName string) bool {
 		}
 	}
 
+	return false
+}
+
+// isPrometheusCRInstalled checks if Prometheus CR exists (for kube-prometheus-stack operator deployments)
+func isPrometheusCRInstalled(k8sClient *k8s.Client) bool {
+	ctx := context.Background()
+
+	// Check for prometheus operator pods - if they're running, prometheus is installed
+	pods, err := k8sClient.GetPods(ctx, "monitoring")
+	if err != nil {
+		return false
+	}
+
+	for _, pod := range pods {
+		if strings.Contains(pod.Name, "kube-prometheus-stack") {
+			return true
+		}
+	}
 	return false
 }
 

--- a/v1/cmd/foundry/registry/init.go
+++ b/v1/cmd/foundry/registry/init.go
@@ -10,11 +10,11 @@ import (
 	"github.com/catalystcommunity/foundry/v1/internal/component/grafana"
 	"github.com/catalystcommunity/foundry/v1/internal/component/k3s"
 	"github.com/catalystcommunity/foundry/v1/internal/component/loki"
-	"github.com/catalystcommunity/foundry/v1/internal/component/openbao"
-	"github.com/catalystcommunity/foundry/v1/internal/component/openbaoinjector"
-	"github.com/catalystcommunity/foundry/v1/internal/component/prometheus"
 	"github.com/catalystcommunity/foundry/v1/internal/component/seaweedfs"
+	"github.com/catalystcommunity/foundry/v1/internal/component/openbao"
+	"github.com/catalystcommunity/foundry/v1/internal/component/prometheus"
 	"github.com/catalystcommunity/foundry/v1/internal/component/storage"
+	"github.com/catalystcommunity/foundry/v1/internal/component/tailscale"
 	"github.com/catalystcommunity/foundry/v1/internal/component/velero"
 	"github.com/catalystcommunity/foundry/v1/internal/component/zot"
 )
@@ -44,11 +44,10 @@ func InitComponents() error {
 		return err
 	}
 
-	// Register OpenBao agent injector - depends on OpenBAO and K3s
-	// Installs the MutatingWebhookConfiguration so pods can receive secrets
-	// from OpenBao via vault.hashicorp.com/agent-inject annotations
-	openbaoInjectorComp := openbaoinjector.NewComponent(nil, nil, nil)
-	if err := component.Register(openbaoInjectorComp); err != nil {
+	// Register Tailscale - depends on K3s
+	// Tailscale provides secure connectivity and VIP subnet route advertisement
+	tailscaleComp := tailscale.NewComponent(nil, "")
+	if err := component.Register(tailscaleComp); err != nil {
 		return err
 	}
 

--- a/v1/internal/component/k3s/types.go
+++ b/v1/internal/component/k3s/types.go
@@ -64,6 +64,11 @@ func ParseConfig(cfg component.ComponentConfig) (*Config, error) {
 		config.VIP = vip
 	}
 
+	// Allow CGNAT VIP
+	if allowCGNAT, ok := cfg.GetBool("allow_cgnat_vip"); ok {
+		config.AllowCGNATVIP = &allowCGNAT
+	}
+
 	// Interface
 	if iface, ok := cfg.GetString("interface"); ok {
 		config.Interface = iface

--- a/v1/internal/component/k3s/vip.go
+++ b/v1/internal/component/k3s/vip.go
@@ -48,7 +48,7 @@ func ValidateVIP(vip string, allowCGNAT bool) error {
 		if allowCGNAT {
 			return fmt.Errorf("VIP should be a private IP address (RFC1918 or RFC6598): %s", vip)
 		}
-		return fmt.Errorf("VIP should be a private IP address: %s (hint: set allow_cgnat_vip: true to use CGNAT IPs in the 100.64.0.0/10 range)", vip)
+		return fmt.Errorf("VIP should be a private IP address: %s (hint: set allow_cgnat_vip: true to use CGNAT IPs in the 100.64.0.0/10 range, e.g. Tailscale)", vip)
 	}
 
 	return nil
@@ -57,9 +57,9 @@ func ValidateVIP(vip string, allowCGNAT bool) error {
 // isPrivateIP checks if an IP is in private ranges (RFC1918) or optionally shared address space (RFC6598)
 func isPrivateIP(ip net.IP, allowCGNAT bool) bool {
 	private := []string{
-		"10.0.0.0/8",        // RFC1918 - Private-Use
-		"172.16.0.0/12",     // RFC1918 - Private-Use
-		"192.168.0.0/16",    // RFC1918 - Private-Use
+		"10.0.0.0/8",     // RFC1918 - Private-Use
+		"172.16.0.0/12",  // RFC1918 - Private-Use
+		"192.168.0.0/16", // RFC1918 - Private-Use
 	}
 
 	// Optionally include CGNAT range (RFC6598) used by Tailscale and similar overlay networks
@@ -106,13 +106,14 @@ func DetermineVIPConfig(vip string, conn network.SSHExecutor, allowCGNAT bool) (
 		return nil, fmt.Errorf("interface detection failed: %w", err)
 	}
 
-	// Convert bool to *bool for VIPConfig
-	allowCGNATPtr := &allowCGNAT
-	return &VIPConfig{
-		VIP:           vip,
-		Interface:     iface,
-		AllowCGNATVIP: allowCGNATPtr,
-	}, nil
+	cfg := &VIPConfig{
+		VIP:       vip,
+		Interface: iface,
+	}
+	if allowCGNAT {
+		cfg.AllowCGNATVIP = &allowCGNAT
+	}
+	return cfg, nil
 }
 
 // GenerateKubeVIPManifest generates the kube-vip DaemonSet manifest YAML

--- a/v1/internal/component/tailscale/component.go
+++ b/v1/internal/component/tailscale/component.go
@@ -1,0 +1,280 @@
+package tailscale
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/catalystcommunity/foundry/v1/internal/component"
+	"github.com/catalystcommunity/foundry/v1/internal/helm"
+	"github.com/catalystcommunity/foundry/v1/internal/k8s"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+)
+
+// Adapters to convert concrete Foundry clients to Tailscale interfaces
+
+// helmClientAdapter adapts *helm.Client to HelmClient interface
+type helmClientAdapter struct {
+	client *helm.Client
+}
+
+func (a *helmClientAdapter) AddRepo(ctx context.Context, opts helm.RepoAddOptions) error {
+	return a.client.AddRepo(ctx, opts)
+}
+
+func (a *helmClientAdapter) Install(ctx context.Context, opts helm.InstallOptions) error {
+	return a.client.Install(ctx, opts)
+}
+
+func (a *helmClientAdapter) Uninstall(ctx context.Context, opts helm.UninstallOptions) error {
+	return a.client.Uninstall(ctx, opts)
+}
+
+// kubeClientAdapter adapts *k8s.Client to KubernetesClient interface
+type kubeClientAdapter struct {
+	client *k8s.Client
+}
+
+func (a *kubeClientAdapter) Apply(ctx context.Context, manifest map[string]interface{}) error {
+	// Convert map to YAML string
+	yamlBytes, err := yaml.Marshal(manifest)
+	if err != nil {
+		return fmt.Errorf("failed to marshal manifest to YAML: %w", err)
+	}
+
+	// Use k8s client's ApplyManifest method
+	return a.client.ApplyManifest(ctx, string(yamlBytes))
+}
+
+func (a *kubeClientAdapter) GetServiceIP(ctx context.Context, namespace, name string) (string, error) {
+	// Get the service using the underlying clientset
+	svc, err := a.client.Clientset().CoreV1().Services(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed to get service %s/%s: %w", namespace, name, err)
+	}
+
+	// Return ClusterIP
+	if svc.Spec.ClusterIP == "" {
+		return "", fmt.Errorf("service %s/%s has no ClusterIP", namespace, name)
+	}
+
+	return svc.Spec.ClusterIP, nil
+}
+
+func (a *kubeClientAdapter) GetConfigMap(ctx context.Context, namespace, name string) (*ConfigMap, error) {
+	// Get ConfigMap using the underlying clientset
+	cm, err := a.client.Clientset().CoreV1().ConfigMaps(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get ConfigMap %s/%s: %w", namespace, name, err)
+	}
+
+	// Convert to our ConfigMap type
+	return &ConfigMap{
+		Name:      cm.Name,
+		Namespace: cm.Namespace,
+		Data:      cm.Data,
+	}, nil
+}
+
+func (a *kubeClientAdapter) UpdateConfigMap(ctx context.Context, cm *ConfigMap) error {
+	// Get existing ConfigMap first
+	existingCM, err := a.client.Clientset().CoreV1().ConfigMaps(cm.Namespace).Get(ctx, cm.Name, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get ConfigMap %s/%s: %w", cm.Namespace, cm.Name, err)
+	}
+
+	// Update the data
+	existingCM.Data = cm.Data
+
+	// Update ConfigMap using the underlying clientset
+	_, err = a.client.Clientset().CoreV1().ConfigMaps(cm.Namespace).Update(ctx, existingCM, metav1.UpdateOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to update ConfigMap %s/%s: %w", cm.Namespace, cm.Name, err)
+	}
+
+	return nil
+}
+
+// Component implements the component.Component interface for Tailscale operator
+type Component struct {
+	config     *Config
+	vip        string
+	helmClient HelmClient
+	kubeClient KubernetesClient
+}
+
+// NewComponent creates a new Tailscale component with the given configuration
+// vip parameter can be empty - it will be extracted from ComponentConfig during Install
+func NewComponent(cfg *Config, vip string) *Component {
+	if cfg == nil {
+		cfg = &Config{}
+	}
+
+	// Set defaults
+	cfg.SetDefaults()
+
+	return &Component{
+		config: cfg,
+		vip:    vip,
+	}
+}
+
+// NewComponentWithClients creates a new Tailscale component with clients pre-configured
+// This is used by the component installer to pass concrete client implementations
+// It wraps the concrete types with adapters that implement our interfaces
+func NewComponentWithClients(cfg *Config, vip string, helmClient *helm.Client, kubeClient *k8s.Client) *Component {
+	if cfg == nil {
+		cfg = &Config{}
+	}
+
+	// Set defaults
+	cfg.SetDefaults()
+
+	// Wrap concrete clients with adapters
+	var hc HelmClient
+	var kc KubernetesClient
+	if helmClient != nil {
+		hc = &helmClientAdapter{client: helmClient}
+	}
+	if kubeClient != nil {
+		kc = &kubeClientAdapter{client: kubeClient}
+	}
+
+	return &Component{
+		config:     cfg,
+		vip:        vip,
+		helmClient: hc,
+		kubeClient: kc,
+	}
+}
+
+// Name returns the component name
+func (c *Component) Name() string {
+	return "tailscale"
+}
+
+// Dependencies returns the list of components that Tailscale depends on
+func (c *Component) Dependencies() []string {
+	// Tailscale operator requires a running Kubernetes cluster
+	return []string{"k3s"}
+}
+
+// Install installs the Tailscale operator component
+func (c *Component) Install(ctx context.Context, cfg component.ComponentConfig) error {
+	// Use pre-configured clients if available, otherwise get from config
+	helmClient := c.helmClient
+	kubeClient := c.kubeClient
+
+	// Fallback to getting clients from component config if not pre-configured
+	if helmClient == nil {
+		if hc, ok := cfg["helm_client"].(HelmClient); ok {
+			helmClient = hc
+		} else {
+			return fmt.Errorf("helm_client not provided")
+		}
+	}
+
+	if kubeClient == nil {
+		if kc, ok := cfg["k8s_client"].(KubernetesClient); ok {
+			kubeClient = kc
+		} else {
+			return fmt.Errorf("k8s_client not provided")
+		}
+	}
+
+	// Extract VIP from config if not already set
+	vip := c.vip
+	if vip == "" {
+		if vipVal, ok := cfg.GetString("vip"); ok {
+			vip = vipVal
+		} else {
+			return fmt.Errorf("vip is required for Tailscale installation")
+		}
+	}
+
+	// Use pre-configured config if available, otherwise parse from ComponentConfig
+	tailscaleConfig := c.config
+	if tailscaleConfig == nil {
+		var err error
+		tailscaleConfig, err = c.parseConfig(cfg)
+		if err != nil {
+			return fmt.Errorf("failed to parse Tailscale config: %w", err)
+		}
+	}
+
+	// Create installer
+	installer, err := NewInstaller(tailscaleConfig, vip, helmClient, kubeClient)
+	if err != nil {
+		return fmt.Errorf("failed to create Tailscale installer: %w", err)
+	}
+
+	// Run installation
+	if err := installer.Install(ctx); err != nil {
+		return fmt.Errorf("Tailscale installation failed: %w", err)
+	}
+
+	return nil
+}
+
+// Upgrade upgrades the Tailscale operator component
+func (c *Component) Upgrade(ctx context.Context, cfg component.ComponentConfig) error {
+	// For now, upgrade uses the same logic as install (Helm handles this)
+	return c.Install(ctx, cfg)
+}
+
+// Status returns the current status of the Tailscale operator
+func (c *Component) Status(ctx context.Context) (*component.ComponentStatus, error) {
+	// TODO: Implement proper status checking
+	// For now, return a basic status
+	return &component.ComponentStatus{
+		Installed: false,
+		Healthy:   false,
+		Version:   "",
+		Message:   "status checking not yet implemented",
+	}, nil
+}
+
+// Uninstall removes the Tailscale operator
+func (c *Component) Uninstall(ctx context.Context) error {
+	// TODO: Implement uninstall
+	return fmt.Errorf("uninstall not yet implemented")
+}
+
+// Config returns the component configuration
+func (c *Component) Config() interface{} {
+	return c.config
+}
+
+// parseConfig parses Tailscale configuration from component config map
+func (c *Component) parseConfig(cfg component.ComponentConfig) (*Config, error) {
+	config := &Config{}
+
+	// OAuth credentials (required)
+	if clientID, ok := cfg.GetString("oauth_client_id"); ok {
+		config.OAuthClientID = &clientID
+	}
+	if clientSecret, ok := cfg.GetString("oauth_client_secret"); ok {
+		config.OAuthClientSecret = &clientSecret
+	}
+
+	// Optional fields
+	if operatorImage, ok := cfg.GetString("operator_image"); ok {
+		config.OperatorImage = &operatorImage
+	}
+	if routes, ok := cfg.GetStringSlice("advertise_routes"); ok {
+		config.AdvertiseRoutes = routes  // Direct assignment, routes is []string
+	}
+	if tags, ok := cfg.GetStringSlice("tags"); ok {
+		config.Tags = tags  // Direct assignment, tags is []string
+	}
+
+	// Validate
+	if err := config.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid Tailscale configuration: %w", err)
+	}
+
+	// Set defaults
+	config.SetDefaults()
+
+	return config, nil
+}

--- a/v1/internal/component/tailscale/coredns.go
+++ b/v1/internal/component/tailscale/coredns.go
@@ -1,0 +1,158 @@
+package tailscale
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+const (
+	// CoreDNS configuration constants
+	CoreDNSNamespace    = "kube-system"
+	CoreDNSConfigMap    = "coredns"
+	CoreDNSConfigKey    = "Corefile"
+	TailscaleDNSService = "ts-dns"
+)
+
+// CoreDNSPatcher handles CoreDNS configuration patching for Tailscale DNS.
+type CoreDNSPatcher struct {
+	client KubernetesClient
+}
+
+// NewCoreDNSPatcher creates a new CoreDNS patcher.
+func NewCoreDNSPatcher(client KubernetesClient) (*CoreDNSPatcher, error) {
+	if client == nil {
+		return nil, fmt.Errorf("kubernetes client cannot be nil")
+	}
+
+	return &CoreDNSPatcher{
+		client: client,
+	}, nil
+}
+
+// PatchCoreDNS patches the CoreDNS ConfigMap to forward .ts.net queries to Tailscale DNS.
+func (p *CoreDNSPatcher) PatchCoreDNS(ctx context.Context) error {
+	// Get Tailscale DNS service IP
+	dnsIP, err := p.getTailscaleDNSIP(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get Tailscale DNS service IP: %w", err)
+	}
+
+	// Get CoreDNS ConfigMap
+	configMap, err := p.client.GetConfigMap(ctx, CoreDNSNamespace, CoreDNSConfigMap)
+	if err != nil {
+		return fmt.Errorf("failed to get CoreDNS ConfigMap: %w", err)
+	}
+
+	// Get Corefile content
+	corefile, ok := configMap.Data[CoreDNSConfigKey]
+	if !ok {
+		return fmt.Errorf("Corefile key not found in ConfigMap")
+	}
+
+	// Patch Corefile
+	patchedCorefile, changed, err := p.patchCorefile(corefile, dnsIP)
+	if err != nil {
+		return fmt.Errorf("failed to patch Corefile: %w", err)
+	}
+
+	// Only update if changes were made
+	if !changed {
+		return nil // Already patched, no-op
+	}
+
+	// Update ConfigMap
+	configMap.Data[CoreDNSConfigKey] = patchedCorefile
+	if err := p.client.UpdateConfigMap(ctx, configMap); err != nil {
+		return fmt.Errorf("failed to update CoreDNS ConfigMap: %w", err)
+	}
+
+	return nil
+}
+
+// getTailscaleDNSIP retrieves the Tailscale DNS service IP.
+func (p *CoreDNSPatcher) getTailscaleDNSIP(ctx context.Context) (string, error) {
+	ip, err := p.client.GetServiceIP(ctx, DefaultNamespace, TailscaleDNSService)
+	if err != nil {
+		return "", fmt.Errorf("failed to get service IP: %w", err)
+	}
+
+	if ip == "" {
+		return "", fmt.Errorf("Tailscale DNS service IP is empty")
+	}
+
+	return ip, nil
+}
+
+// patchCorefile adds the Tailscale DNS forwarding block to the Corefile.
+// Returns the patched Corefile, whether changes were made, and any error.
+func (p *CoreDNSPatcher) patchCorefile(corefile, dnsIP string) (string, bool, error) {
+	// Check if already patched
+	if strings.Contains(corefile, "ts.net:53") {
+		return corefile, false, nil // Already patched
+	}
+
+	// Generate Tailscale block
+	tsBlock := p.generateTailscaleBlock(dnsIP)
+
+	// Insert block at the beginning (before other blocks)
+	patchedCorefile := tsBlock + "\n" + corefile
+
+	return patchedCorefile, true, nil
+}
+
+// generateTailscaleBlock creates the Tailscale DNS forwarding configuration block.
+func (p *CoreDNSPatcher) generateTailscaleBlock(dnsIP string) string {
+	return fmt.Sprintf(`ts.net:53 {
+    errors
+    cache 30
+    forward . %s
+}`, dnsIP)
+}
+
+// ParseCorefile parses a Corefile into individual server blocks.
+// This is a helper function for more advanced parsing if needed in the future.
+func ParseCorefile(corefile string) []string {
+	var blocks []string
+	var currentBlock strings.Builder
+	inBlock := false
+	braceDepth := 0
+
+	lines := strings.Split(corefile, "\n")
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+
+		// Count braces to track block depth
+		openBraces := strings.Count(line, "{")
+		closeBraces := strings.Count(line, "}")
+		braceDepth += openBraces - closeBraces
+
+		// Start of a block (line with port like ".:53" or "ts.net:53")
+		if !inBlock && strings.Contains(trimmed, ":") && strings.Contains(trimmed, "{") {
+			inBlock = true
+		}
+
+		if inBlock {
+			currentBlock.WriteString(line)
+			currentBlock.WriteString("\n")
+
+			// End of block when braces balance
+			if braceDepth == 0 {
+				blocks = append(blocks, strings.TrimSpace(currentBlock.String()))
+				currentBlock.Reset()
+				inBlock = false
+			}
+		} else if trimmed != "" {
+			// Standalone lines outside blocks (comments, etc.)
+			currentBlock.WriteString(line)
+			currentBlock.WriteString("\n")
+		}
+	}
+
+	// Capture any remaining content
+	if currentBlock.Len() > 0 {
+		blocks = append(blocks, strings.TrimSpace(currentBlock.String()))
+	}
+
+	return blocks
+}

--- a/v1/internal/component/tailscale/coredns_test.go
+++ b/v1/internal/component/tailscale/coredns_test.go
@@ -1,0 +1,573 @@
+package tailscale
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// mockKubernetesClientExtended extends mockKubernetesClient with CoreDNS methods
+type mockKubernetesClientExtended struct {
+	mockKubernetesClient // Embed the existing mock from crds_test.go
+
+	// Service IP lookup
+	serviceIP    string
+	serviceIPErr error
+
+	// ConfigMap operations
+	configMap       *ConfigMap
+	getConfigMapErr error
+	updateConfigMapErr error
+	configMapsUpdated []*ConfigMap
+}
+
+func (m *mockKubernetesClientExtended) GetServiceIP(ctx context.Context, namespace, name string) (string, error) {
+	if m.serviceIPErr != nil {
+		return "", m.serviceIPErr
+	}
+	return m.serviceIP, nil
+}
+
+func (m *mockKubernetesClientExtended) GetConfigMap(ctx context.Context, namespace, name string) (*ConfigMap, error) {
+	if m.getConfigMapErr != nil {
+		return nil, m.getConfigMapErr
+	}
+	// Return a copy to avoid mutation issues
+	if m.configMap != nil {
+		return &ConfigMap{
+			Name:      m.configMap.Name,
+			Namespace: m.configMap.Namespace,
+			Data:      copyMap(m.configMap.Data),
+		}, nil
+	}
+	return nil, fmt.Errorf("ConfigMap not found")
+}
+
+func (m *mockKubernetesClientExtended) UpdateConfigMap(ctx context.Context, cm *ConfigMap) error {
+	if m.updateConfigMapErr != nil {
+		return m.updateConfigMapErr
+	}
+	// Store a copy of the updated ConfigMap
+	m.configMapsUpdated = append(m.configMapsUpdated, &ConfigMap{
+		Name:      cm.Name,
+		Namespace: cm.Namespace,
+		Data:      copyMap(cm.Data),
+	})
+	return nil
+}
+
+func copyMap(m map[string]string) map[string]string {
+	result := make(map[string]string)
+	for k, v := range m {
+		result[k] = v
+	}
+	return result
+}
+
+func TestNewCoreDNSPatcher(t *testing.T) {
+	tests := []struct {
+		name    string
+		client  KubernetesClient
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "nil client",
+			client:  nil,
+			wantErr: true,
+			errMsg:  "kubernetes client cannot be nil",
+		},
+		{
+			name:    "valid client",
+			client:  &mockKubernetesClientExtended{},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			patcher, err := NewCoreDNSPatcher(tt.client)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewCoreDNSPatcher() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if err != nil && tt.errMsg != "" && err.Error() != tt.errMsg {
+				t.Errorf("NewCoreDNSPatcher() error message = %q, want %q", err.Error(), tt.errMsg)
+				return
+			}
+			if !tt.wantErr && patcher == nil {
+				t.Error("NewCoreDNSPatcher() returned nil patcher without error")
+			}
+		})
+	}
+}
+
+func TestCoreDNSPatcher_GenerateTailscaleBlock(t *testing.T) {
+	tests := []struct {
+		name    string
+		dnsIP   string
+		wantContains []string
+	}{
+		{
+			name:  "IPv4 address",
+			dnsIP: "10.96.0.100",
+			wantContains: []string{
+				"ts.net:53 {",
+				"errors",
+				"cache 30",
+				"forward . 10.96.0.100",
+				"}",
+			},
+		},
+		{
+			name:  "different IPv4",
+			dnsIP: "192.168.1.53",
+			wantContains: []string{
+				"forward . 192.168.1.53",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &mockKubernetesClientExtended{}
+			patcher, err := NewCoreDNSPatcher(client)
+			if err != nil {
+				t.Fatalf("NewCoreDNSPatcher() unexpected error: %v", err)
+			}
+
+			block := patcher.generateTailscaleBlock(tt.dnsIP)
+
+			for _, want := range tt.wantContains {
+				if !strings.Contains(block, want) {
+					t.Errorf("generateTailscaleBlock() missing %q in output:\n%s", want, block)
+				}
+			}
+		})
+	}
+}
+
+func TestCoreDNSPatcher_PatchCorefile(t *testing.T) {
+	tests := []struct {
+		name         string
+		corefile     string
+		dnsIP        string
+		wantChanged  bool
+		wantContains []string
+		wantErr      bool
+	}{
+		{
+			name: "clean corefile",
+			corefile: `.:53 {
+    errors
+    health
+    ready
+    kubernetes cluster.local in-addr.arpa ip6.arpa {
+       pods insecure
+       fallthrough in-addr.arpa ip6.arpa
+    }
+    forward . /etc/resolv.conf
+    cache 30
+    loop
+    reload
+    loadbalance
+}`,
+			dnsIP:       "10.96.0.100",
+			wantChanged: true,
+			wantContains: []string{
+				"ts.net:53 {",
+				"forward . 10.96.0.100",
+				".:53 {",
+			},
+		},
+		{
+			name: "already patched",
+			corefile: `ts.net:53 {
+    errors
+    cache 30
+    forward . 10.96.0.100
+}
+
+.:53 {
+    errors
+    health
+}`,
+			dnsIP:       "10.96.0.100",
+			wantChanged: false,
+		},
+		{
+			name:         "empty corefile",
+			corefile:     "",
+			dnsIP:        "10.96.0.100",
+			wantChanged:  true,
+			wantContains: []string{"ts.net:53 {"},
+		},
+		{
+			name: "corefile with comments",
+			corefile: `# CoreDNS configuration
+.:53 {
+    errors
+    health
+}`,
+			dnsIP:       "10.96.0.100",
+			wantChanged: true,
+			wantContains: []string{
+				"ts.net:53 {",
+				"# CoreDNS configuration",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &mockKubernetesClientExtended{}
+			patcher, err := NewCoreDNSPatcher(client)
+			if err != nil {
+				t.Fatalf("NewCoreDNSPatcher() unexpected error: %v", err)
+			}
+
+			patched, changed, err := patcher.patchCorefile(tt.corefile, tt.dnsIP)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("patchCorefile() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if changed != tt.wantChanged {
+				t.Errorf("patchCorefile() changed = %v, want %v", changed, tt.wantChanged)
+			}
+
+			for _, want := range tt.wantContains {
+				if !strings.Contains(patched, want) {
+					t.Errorf("patchCorefile() missing %q in output:\n%s", want, patched)
+				}
+			}
+
+			// Verify original content preserved (if changed)
+			if tt.wantChanged && tt.corefile != "" {
+				if !strings.Contains(patched, tt.corefile) {
+					t.Error("patchCorefile() did not preserve original Corefile content")
+				}
+			}
+		})
+	}
+}
+
+func TestCoreDNSPatcher_GetTailscaleDNSIP(t *testing.T) {
+	tests := []struct {
+		name      string
+		serviceIP string
+		err       error
+		wantIP    string
+		wantErr   bool
+		errMsg    string
+	}{
+		{
+			name:      "successful lookup",
+			serviceIP: "10.96.0.100",
+			wantIP:    "10.96.0.100",
+			wantErr:   false,
+		},
+		{
+			name:      "service not found",
+			serviceIP: "",
+			err:       fmt.Errorf("service not found"),
+			wantErr:   true,
+			errMsg:    "failed to get service IP: service not found",
+		},
+		{
+			name:      "empty IP",
+			serviceIP: "",
+			wantErr:   true,
+			errMsg:    "Tailscale DNS service IP is empty",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &mockKubernetesClientExtended{
+				serviceIP:    tt.serviceIP,
+				serviceIPErr: tt.err,
+			}
+			patcher, err := NewCoreDNSPatcher(client)
+			if err != nil {
+				t.Fatalf("NewCoreDNSPatcher() unexpected error: %v", err)
+			}
+
+			ip, err := patcher.getTailscaleDNSIP(context.Background())
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getTailscaleDNSIP() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if err != nil && tt.errMsg != "" && err.Error() != tt.errMsg {
+				t.Errorf("getTailscaleDNSIP() error message = %q, want %q", err.Error(), tt.errMsg)
+				return
+			}
+			if !tt.wantErr && ip != tt.wantIP {
+				t.Errorf("getTailscaleDNSIP() = %q, want %q", ip, tt.wantIP)
+			}
+		})
+	}
+}
+
+func TestCoreDNSPatcher_PatchCoreDNS(t *testing.T) {
+	tests := []struct {
+		name               string
+		serviceIP          string
+		serviceIPErr       error
+		configMap          *ConfigMap
+		getConfigMapErr    error
+		updateConfigMapErr error
+		wantErr            bool
+		wantUpdateCalled   bool
+		errContains        string
+	}{
+		{
+			name:      "successful patch",
+			serviceIP: "10.96.0.100",
+			configMap: &ConfigMap{
+				Name:      "coredns",
+				Namespace: "kube-system",
+				Data: map[string]string{
+					"Corefile": `.:53 {
+    errors
+    health
+}`,
+				},
+			},
+			wantErr:          false,
+			wantUpdateCalled: true,
+		},
+		{
+			name:      "already patched - no update",
+			serviceIP: "10.96.0.100",
+			configMap: &ConfigMap{
+				Name:      "coredns",
+				Namespace: "kube-system",
+				Data: map[string]string{
+					"Corefile": `ts.net:53 {
+    errors
+    cache 30
+    forward . 10.96.0.100
+}
+
+.:53 {
+    errors
+}`,
+				},
+			},
+			wantErr:          false,
+			wantUpdateCalled: false, // Should not update if already patched
+		},
+		{
+			name:         "service IP lookup error",
+			serviceIP:    "",
+			serviceIPErr: fmt.Errorf("service not found"),
+			wantErr:      true,
+			errContains:  "failed to get Tailscale DNS service IP",
+		},
+		{
+			name:            "configmap get error",
+			serviceIP:       "10.96.0.100",
+			getConfigMapErr: fmt.Errorf("ConfigMap not found"),
+			wantErr:         true,
+			errContains:     "failed to get CoreDNS ConfigMap",
+		},
+		{
+			name:      "missing Corefile key",
+			serviceIP: "10.96.0.100",
+			configMap: &ConfigMap{
+				Name:      "coredns",
+				Namespace: "kube-system",
+				Data:      map[string]string{}, // No Corefile key
+			},
+			wantErr:     true,
+			errContains: "Corefile key not found",
+		},
+		{
+			name:      "update error",
+			serviceIP: "10.96.0.100",
+			configMap: &ConfigMap{
+				Name:      "coredns",
+				Namespace: "kube-system",
+				Data: map[string]string{
+					"Corefile": `.:53 {
+    errors
+}`,
+				},
+			},
+			updateConfigMapErr: fmt.Errorf("update failed"),
+			wantErr:            true,
+			errContains:        "failed to update CoreDNS ConfigMap",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &mockKubernetesClientExtended{
+				serviceIP:          tt.serviceIP,
+				serviceIPErr:       tt.serviceIPErr,
+				configMap:          tt.configMap,
+				getConfigMapErr:    tt.getConfigMapErr,
+				updateConfigMapErr: tt.updateConfigMapErr,
+				configMapsUpdated:  []*ConfigMap{},
+			}
+			patcher, err := NewCoreDNSPatcher(client)
+			if err != nil {
+				t.Fatalf("NewCoreDNSPatcher() unexpected error: %v", err)
+			}
+
+			err = patcher.PatchCoreDNS(context.Background())
+			if (err != nil) != tt.wantErr {
+				t.Errorf("PatchCoreDNS() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if err != nil && tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+				t.Errorf("PatchCoreDNS() error = %q, want to contain %q", err.Error(), tt.errContains)
+				return
+			}
+
+			// Check if update was called as expected
+			updateCalled := len(client.configMapsUpdated) > 0
+			if updateCalled != tt.wantUpdateCalled {
+				t.Errorf("PatchCoreDNS() update called = %v, want %v", updateCalled, tt.wantUpdateCalled)
+			}
+
+			// Verify patched content if update was called
+			if tt.wantUpdateCalled && len(client.configMapsUpdated) > 0 {
+				updatedCM := client.configMapsUpdated[0]
+				corefile := updatedCM.Data["Corefile"]
+				if !strings.Contains(corefile, "ts.net:53") {
+					t.Error("PatchCoreDNS() updated ConfigMap missing ts.net:53 block")
+				}
+				if !strings.Contains(corefile, tt.serviceIP) {
+					t.Errorf("PatchCoreDNS() updated ConfigMap missing service IP %s", tt.serviceIP)
+				}
+			}
+		})
+	}
+}
+
+func TestCoreDNSPatcher_PatchCoreDNS_Idempotency(t *testing.T) {
+	// Test that patching twice results in the same Corefile
+	serviceIP := "10.96.0.100"
+	originalCorefile := `.:53 {
+    errors
+    health
+    kubernetes cluster.local
+    forward . /etc/resolv.conf
+}`
+
+	client := &mockKubernetesClientExtended{
+		serviceIP: serviceIP,
+		configMap: &ConfigMap{
+			Name:      "coredns",
+			Namespace: "kube-system",
+			Data: map[string]string{
+				"Corefile": originalCorefile,
+			},
+		},
+		configMapsUpdated: []*ConfigMap{},
+	}
+
+	patcher, err := NewCoreDNSPatcher(client)
+	if err != nil {
+		t.Fatalf("NewCoreDNSPatcher() unexpected error: %v", err)
+	}
+
+	// First patch
+	if err := patcher.PatchCoreDNS(context.Background()); err != nil {
+		t.Fatalf("First PatchCoreDNS() unexpected error: %v", err)
+	}
+
+	if len(client.configMapsUpdated) != 1 {
+		t.Fatalf("Expected 1 update after first patch, got %d", len(client.configMapsUpdated))
+	}
+
+	firstPatchedCorefile := client.configMapsUpdated[0].Data["Corefile"]
+
+	// Update mock with patched Corefile for second patch
+	client.configMap.Data["Corefile"] = firstPatchedCorefile
+	client.configMapsUpdated = []*ConfigMap{} // Reset
+
+	// Second patch (should be no-op)
+	if err := patcher.PatchCoreDNS(context.Background()); err != nil {
+		t.Fatalf("Second PatchCoreDNS() unexpected error: %v", err)
+	}
+
+	if len(client.configMapsUpdated) != 0 {
+		t.Errorf("Expected 0 updates after second patch (idempotent), got %d", len(client.configMapsUpdated))
+	}
+
+	// Verify ts.net block appears only once
+	count := strings.Count(firstPatchedCorefile, "ts.net:53")
+	if count != 1 {
+		t.Errorf("Expected ts.net:53 to appear once, found %d times", count)
+	}
+}
+
+func TestParseCorefile(t *testing.T) {
+	tests := []struct {
+		name       string
+		corefile   string
+		wantBlocks int
+		wantContains []string
+	}{
+		{
+			name: "single block",
+			corefile: `.:53 {
+    errors
+    health
+}`,
+			wantBlocks: 1,
+			wantContains: []string{".:53"},
+		},
+		{
+			name: "multiple blocks",
+			corefile: `ts.net:53 {
+    forward . 10.96.0.100
+}
+
+.:53 {
+    errors
+    health
+}`,
+			wantBlocks: 2,
+			wantContains: []string{"ts.net:53", ".:53"},
+		},
+		{
+			name: "complex block with nested braces",
+			corefile: `.:53 {
+    errors
+    kubernetes cluster.local {
+       pods insecure
+    }
+    forward . /etc/resolv.conf
+}`,
+			wantBlocks: 1,
+			wantContains: []string{"kubernetes cluster.local"},
+		},
+		{
+			name:       "empty corefile",
+			corefile:   "",
+			wantBlocks: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			blocks := ParseCorefile(tt.corefile)
+
+			if len(blocks) != tt.wantBlocks {
+				t.Errorf("ParseCorefile() returned %d blocks, want %d", len(blocks), tt.wantBlocks)
+			}
+
+			combinedBlocks := strings.Join(blocks, " ")
+			for _, want := range tt.wantContains {
+				if !strings.Contains(combinedBlocks, want) {
+					t.Errorf("ParseCorefile() blocks missing %q", want)
+				}
+			}
+		})
+	}
+}

--- a/v1/internal/component/tailscale/crds.go
+++ b/v1/internal/component/tailscale/crds.go
@@ -5,10 +5,20 @@ import (
 	"fmt"
 )
 
+// ConfigMap represents a Kubernetes ConfigMap resource.
+type ConfigMap struct {
+	Name      string
+	Namespace string
+	Data      map[string]string
+}
+
 // KubernetesClient defines the interface for Kubernetes operations needed by Tailscale installer.
 // This interface allows for easier testing with mock implementations.
 type KubernetesClient interface {
 	Apply(ctx context.Context, manifest map[string]interface{}) error
+	GetServiceIP(ctx context.Context, namespace, name string) (string, error)
+	GetConfigMap(ctx context.Context, namespace, name string) (*ConfigMap, error)
+	UpdateConfigMap(ctx context.Context, cm *ConfigMap) error
 }
 
 // CRDInstaller handles CRD deployment for Tailscale operator.

--- a/v1/internal/component/tailscale/crds.go
+++ b/v1/internal/component/tailscale/crds.go
@@ -1,0 +1,120 @@
+package tailscale
+
+import (
+	"context"
+	"fmt"
+)
+
+// KubernetesClient defines the interface for Kubernetes operations needed by Tailscale installer.
+// This interface allows for easier testing with mock implementations.
+type KubernetesClient interface {
+	Apply(ctx context.Context, manifest map[string]interface{}) error
+}
+
+// CRDInstaller handles CRD deployment for Tailscale operator.
+type CRDInstaller struct {
+	client KubernetesClient
+	config *Config
+	vip    string
+}
+
+// NewCRDInstaller creates a new CRD installer for Tailscale.
+func NewCRDInstaller(client KubernetesClient, config *Config, vip string) (*CRDInstaller, error) {
+	if client == nil {
+		return nil, fmt.Errorf("kubernetes client cannot be nil")
+	}
+	if config == nil {
+		return nil, fmt.Errorf("config cannot be nil")
+	}
+	if vip == "" {
+		return nil, fmt.Errorf("VIP cannot be empty")
+	}
+
+	return &CRDInstaller{
+		client: client,
+		config: config,
+		vip:    vip,
+	}, nil
+}
+
+// DeployConnector deploys the Tailscale Connector CRD for subnet route advertisement.
+func (c *CRDInstaller) DeployConnector(ctx context.Context) error {
+	connector, err := c.generateConnectorManifest()
+	if err != nil {
+		return fmt.Errorf("failed to generate Connector manifest: %w", err)
+	}
+
+	if err := c.client.Apply(ctx, connector); err != nil {
+		return fmt.Errorf("failed to apply Connector CRD: %w", err)
+	}
+
+	return nil
+}
+
+// DeployDNSConfig deploys the Tailscale DNSConfig CRD for Magic DNS.
+func (c *CRDInstaller) DeployDNSConfig(ctx context.Context) error {
+	dnsConfig, err := c.generateDNSConfigManifest()
+	if err != nil {
+		return fmt.Errorf("failed to generate DNSConfig manifest: %w", err)
+	}
+
+	if err := c.client.Apply(ctx, dnsConfig); err != nil {
+		return fmt.Errorf("failed to apply DNSConfig CRD: %w", err)
+	}
+
+	return nil
+}
+
+// generateConnectorManifest creates the Connector CRD manifest.
+func (c *CRDInstaller) generateConnectorManifest() (map[string]interface{}, error) {
+	// Build advertised routes: VIP + any additional routes from config
+	routes := []string{fmt.Sprintf("%s/32", c.vip)}
+	if c.config.AdvertiseRoutes != nil {
+		routes = append(routes, c.config.AdvertiseRoutes...)
+	}
+
+	// Build tags: default tag + any additional tags from config
+	tags := []string{"tag:k8s-foundry"}
+	if c.config.Tags != nil {
+		tags = append(tags, c.config.Tags...)
+	}
+
+	connector := map[string]interface{}{
+		"apiVersion": "tailscale.com/v1alpha1",
+		"kind":       "Connector",
+		"metadata": map[string]interface{}{
+			"name":      "foundry-vip-connector",
+			"namespace": DefaultNamespace,
+		},
+		"spec": map[string]interface{}{
+			"tags": tags,
+			"subnetRouter": map[string]interface{}{
+				"advertiseRoutes": routes,
+			},
+		},
+	}
+
+	return connector, nil
+}
+
+// generateDNSConfigManifest creates the DNSConfig CRD manifest.
+func (c *CRDInstaller) generateDNSConfigManifest() (map[string]interface{}, error) {
+	dnsConfig := map[string]interface{}{
+		"apiVersion": "tailscale.com/v1alpha1",
+		"kind":       "DNSConfig",
+		"metadata": map[string]interface{}{
+			"name":      "ts-dns",
+			"namespace": DefaultNamespace,
+		},
+		"spec": map[string]interface{}{
+			"nameserver": map[string]interface{}{
+				"image": map[string]interface{}{
+					"repo": "tailscale/k8s-nameserver",
+					"tag":  "unstable",
+				},
+			},
+		},
+	}
+
+	return dnsConfig, nil
+}

--- a/v1/internal/component/tailscale/crds_test.go
+++ b/v1/internal/component/tailscale/crds_test.go
@@ -21,6 +21,19 @@ func (m *mockKubernetesClient) Apply(ctx context.Context, manifest map[string]in
 	return nil
 }
 
+// Stub implementations for new interface methods (not used in CRD tests)
+func (m *mockKubernetesClient) GetServiceIP(ctx context.Context, namespace, name string) (string, error) {
+	return "", fmt.Errorf("GetServiceIP not implemented in basic mock")
+}
+
+func (m *mockKubernetesClient) GetConfigMap(ctx context.Context, namespace, name string) (*ConfigMap, error) {
+	return nil, fmt.Errorf("GetConfigMap not implemented in basic mock")
+}
+
+func (m *mockKubernetesClient) UpdateConfigMap(ctx context.Context, cm *ConfigMap) error {
+	return fmt.Errorf("UpdateConfigMap not implemented in basic mock")
+}
+
 func TestNewCRDInstaller(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/v1/internal/component/tailscale/crds_test.go
+++ b/v1/internal/component/tailscale/crds_test.go
@@ -1,0 +1,493 @@
+package tailscale
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+// mockKubernetesClient is a mock implementation of KubernetesClient for testing.
+type mockKubernetesClient struct {
+	applyErr        error
+	manifestsApplied []map[string]interface{}
+}
+
+func (m *mockKubernetesClient) Apply(ctx context.Context, manifest map[string]interface{}) error {
+	if m.applyErr != nil {
+		return m.applyErr
+	}
+	m.manifestsApplied = append(m.manifestsApplied, manifest)
+	return nil
+}
+
+func TestNewCRDInstaller(t *testing.T) {
+	tests := []struct {
+		name    string
+		client  KubernetesClient
+		config  *Config
+		vip     string
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "nil client",
+			client:  nil,
+			config:  &Config{},
+			vip:     "100.81.89.100",
+			wantErr: true,
+			errMsg:  "kubernetes client cannot be nil",
+		},
+		{
+			name:    "nil config",
+			client:  &mockKubernetesClient{},
+			config:  nil,
+			vip:     "100.81.89.100",
+			wantErr: true,
+			errMsg:  "config cannot be nil",
+		},
+		{
+			name:    "empty VIP",
+			client:  &mockKubernetesClient{},
+			config:  &Config{},
+			vip:     "",
+			wantErr: true,
+			errMsg:  "VIP cannot be empty",
+		},
+		{
+			name:    "valid parameters",
+			client:  &mockKubernetesClient{},
+			config:  &Config{},
+			vip:     "100.81.89.100",
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			installer, err := NewCRDInstaller(tt.client, tt.config, tt.vip)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewCRDInstaller() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if err != nil && tt.errMsg != "" && err.Error() != tt.errMsg {
+				t.Errorf("NewCRDInstaller() error message = %q, want %q", err.Error(), tt.errMsg)
+				return
+			}
+			if !tt.wantErr && installer == nil {
+				t.Error("NewCRDInstaller() returned nil installer without error")
+			}
+		})
+	}
+}
+
+func TestCRDInstaller_GenerateConnectorManifest(t *testing.T) {
+	tests := []struct {
+		name           string
+		config         *Config
+		vip            string
+		wantRoutes     []string
+		wantTags       []string
+		wantName       string
+		wantNamespace  string
+		wantAPIVersion string
+		wantKind       string
+	}{
+		{
+			name: "minimal config - VIP only",
+			config: &Config{
+				Tags:            []string{},
+				AdvertiseRoutes: []string{},
+			},
+			vip:            "100.81.89.100",
+			wantRoutes:     []string{"100.81.89.100/32"},
+			wantTags:       []string{"tag:k8s-foundry"},
+			wantName:       "foundry-vip-connector",
+			wantNamespace:  "tailscale",
+			wantAPIVersion: "tailscale.com/v1alpha1",
+			wantKind:       "Connector",
+		},
+		{
+			name: "VIP with additional routes",
+			config: &Config{
+				Tags:            []string{},
+				AdvertiseRoutes: []string{"10.0.0.0/8", "192.168.0.0/16"},
+			},
+			vip:            "100.81.89.100",
+			wantRoutes:     []string{"100.81.89.100/32", "10.0.0.0/8", "192.168.0.0/16"},
+			wantTags:       []string{"tag:k8s-foundry"},
+			wantName:       "foundry-vip-connector",
+			wantNamespace:  "tailscale",
+			wantAPIVersion: "tailscale.com/v1alpha1",
+			wantKind:       "Connector",
+		},
+		{
+			name: "custom tags",
+			config: &Config{
+				Tags:            []string{"tag:production", "tag:us-west"},
+				AdvertiseRoutes: []string{},
+			},
+			vip:            "100.81.89.100",
+			wantRoutes:     []string{"100.81.89.100/32"},
+			wantTags:       []string{"tag:k8s-foundry", "tag:production", "tag:us-west"},
+			wantName:       "foundry-vip-connector",
+			wantNamespace:  "tailscale",
+			wantAPIVersion: "tailscale.com/v1alpha1",
+			wantKind:       "Connector",
+		},
+		{
+			name: "full config",
+			config: &Config{
+				Tags:            []string{"tag:production"},
+				AdvertiseRoutes: []string{"10.0.0.0/8"},
+			},
+			vip:            "100.125.196.1",
+			wantRoutes:     []string{"100.125.196.1/32", "10.0.0.0/8"},
+			wantTags:       []string{"tag:k8s-foundry", "tag:production"},
+			wantName:       "foundry-vip-connector",
+			wantNamespace:  "tailscale",
+			wantAPIVersion: "tailscale.com/v1alpha1",
+			wantKind:       "Connector",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &mockKubernetesClient{}
+			installer, err := NewCRDInstaller(client, tt.config, tt.vip)
+			if err != nil {
+				t.Fatalf("NewCRDInstaller() unexpected error: %v", err)
+			}
+
+			manifest, err := installer.generateConnectorManifest()
+			if err != nil {
+				t.Fatalf("generateConnectorManifest() unexpected error: %v", err)
+			}
+
+			// Verify API version
+			if apiVersion, ok := manifest["apiVersion"].(string); !ok || apiVersion != tt.wantAPIVersion {
+				t.Errorf("apiVersion = %q, want %q", apiVersion, tt.wantAPIVersion)
+			}
+
+			// Verify kind
+			if kind, ok := manifest["kind"].(string); !ok || kind != tt.wantKind {
+				t.Errorf("kind = %q, want %q", kind, tt.wantKind)
+			}
+
+			// Verify metadata
+			metadata, ok := manifest["metadata"].(map[string]interface{})
+			if !ok {
+				t.Fatal("metadata is not a map")
+			}
+			if name, ok := metadata["name"].(string); !ok || name != tt.wantName {
+				t.Errorf("metadata.name = %q, want %q", name, tt.wantName)
+			}
+			if namespace, ok := metadata["namespace"].(string); !ok || namespace != tt.wantNamespace {
+				t.Errorf("metadata.namespace = %q, want %q", namespace, tt.wantNamespace)
+			}
+
+			// Verify spec
+			spec, ok := manifest["spec"].(map[string]interface{})
+			if !ok {
+				t.Fatal("spec is not a map")
+			}
+
+			// Verify tags
+			tags, ok := spec["tags"].([]string)
+			if !ok {
+				t.Fatal("spec.tags is not a string slice")
+			}
+			if !reflect.DeepEqual(tags, tt.wantTags) {
+				t.Errorf("spec.tags = %v, want %v", tags, tt.wantTags)
+			}
+
+			// Verify subnet router
+			subnetRouter, ok := spec["subnetRouter"].(map[string]interface{})
+			if !ok {
+				t.Fatal("spec.subnetRouter is not a map")
+			}
+			routes, ok := subnetRouter["advertiseRoutes"].([]string)
+			if !ok {
+				t.Fatal("spec.subnetRouter.advertiseRoutes is not a string slice")
+			}
+			if !reflect.DeepEqual(routes, tt.wantRoutes) {
+				t.Errorf("spec.subnetRouter.advertiseRoutes = %v, want %v", routes, tt.wantRoutes)
+			}
+		})
+	}
+}
+
+func TestCRDInstaller_GenerateDNSConfigManifest(t *testing.T) {
+	tests := []struct {
+		name           string
+		wantName       string
+		wantNamespace  string
+		wantAPIVersion string
+		wantKind       string
+		wantImageRepo  string
+		wantImageTag   string
+	}{
+		{
+			name:           "default DNSConfig",
+			wantName:       "ts-dns",
+			wantNamespace:  "tailscale",
+			wantAPIVersion: "tailscale.com/v1alpha1",
+			wantKind:       "DNSConfig",
+			wantImageRepo:  "tailscale/k8s-nameserver",
+			wantImageTag:   "unstable",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &mockKubernetesClient{}
+			config := &Config{
+				Tags:            []string{},
+				AdvertiseRoutes: []string{},
+			}
+			installer, err := NewCRDInstaller(client, config, "100.81.89.100")
+			if err != nil {
+				t.Fatalf("NewCRDInstaller() unexpected error: %v", err)
+			}
+
+			manifest, err := installer.generateDNSConfigManifest()
+			if err != nil {
+				t.Fatalf("generateDNSConfigManifest() unexpected error: %v", err)
+			}
+
+			// Verify API version
+			if apiVersion, ok := manifest["apiVersion"].(string); !ok || apiVersion != tt.wantAPIVersion {
+				t.Errorf("apiVersion = %q, want %q", apiVersion, tt.wantAPIVersion)
+			}
+
+			// Verify kind
+			if kind, ok := manifest["kind"].(string); !ok || kind != tt.wantKind {
+				t.Errorf("kind = %q, want %q", kind, tt.wantKind)
+			}
+
+			// Verify metadata
+			metadata, ok := manifest["metadata"].(map[string]interface{})
+			if !ok {
+				t.Fatal("metadata is not a map")
+			}
+			if name, ok := metadata["name"].(string); !ok || name != tt.wantName {
+				t.Errorf("metadata.name = %q, want %q", name, tt.wantName)
+			}
+			if namespace, ok := metadata["namespace"].(string); !ok || namespace != tt.wantNamespace {
+				t.Errorf("metadata.namespace = %q, want %q", namespace, tt.wantNamespace)
+			}
+
+			// Verify spec
+			spec, ok := manifest["spec"].(map[string]interface{})
+			if !ok {
+				t.Fatal("spec is not a map")
+			}
+
+			// Verify nameserver
+			nameserver, ok := spec["nameserver"].(map[string]interface{})
+			if !ok {
+				t.Fatal("spec.nameserver is not a map")
+			}
+
+			// Verify image
+			image, ok := nameserver["image"].(map[string]interface{})
+			if !ok {
+				t.Fatal("spec.nameserver.image is not a map")
+			}
+			if repo, ok := image["repo"].(string); !ok || repo != tt.wantImageRepo {
+				t.Errorf("spec.nameserver.image.repo = %q, want %q", repo, tt.wantImageRepo)
+			}
+			if tag, ok := image["tag"].(string); !ok || tag != tt.wantImageTag {
+				t.Errorf("spec.nameserver.image.tag = %q, want %q", tag, tt.wantImageTag)
+			}
+		})
+	}
+}
+
+func TestCRDInstaller_DeployConnector(t *testing.T) {
+	tests := []struct {
+		name      string
+		client    *mockKubernetesClient
+		config    *Config
+		vip       string
+		wantErr   bool
+		errMsg    string
+		wantCalls int
+	}{
+		{
+			name: "successful deployment",
+			client: &mockKubernetesClient{
+				manifestsApplied: []map[string]interface{}{},
+			},
+			config: &Config{
+				Tags:            []string{},
+				AdvertiseRoutes: []string{},
+			},
+			vip:       "100.81.89.100",
+			wantErr:   false,
+			wantCalls: 1,
+		},
+		{
+			name: "apply error",
+			client: &mockKubernetesClient{
+				applyErr: fmt.Errorf("kubernetes API error"),
+			},
+			config: &Config{
+				Tags:            []string{},
+				AdvertiseRoutes: []string{},
+			},
+			vip:     "100.81.89.100",
+			wantErr: true,
+			errMsg:  "failed to apply Connector CRD: kubernetes API error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			installer, err := NewCRDInstaller(tt.client, tt.config, tt.vip)
+			if err != nil {
+				t.Fatalf("NewCRDInstaller() unexpected error: %v", err)
+			}
+
+			err = installer.DeployConnector(context.Background())
+			if (err != nil) != tt.wantErr {
+				t.Errorf("DeployConnector() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if err != nil && tt.errMsg != "" && err.Error() != tt.errMsg {
+				t.Errorf("DeployConnector() error message = %q, want %q", err.Error(), tt.errMsg)
+				return
+			}
+
+			if !tt.wantErr {
+				if len(tt.client.manifestsApplied) != tt.wantCalls {
+					t.Errorf("Apply() called %d times, want %d", len(tt.client.manifestsApplied), tt.wantCalls)
+				}
+
+				// Verify Connector manifest was applied
+				if len(tt.client.manifestsApplied) > 0 {
+					manifest := tt.client.manifestsApplied[0]
+					if kind, ok := manifest["kind"].(string); !ok || kind != "Connector" {
+						t.Errorf("Applied manifest kind = %q, want %q", kind, "Connector")
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestCRDInstaller_DeployDNSConfig(t *testing.T) {
+	tests := []struct {
+		name      string
+		client    *mockKubernetesClient
+		config    *Config
+		vip       string
+		wantErr   bool
+		errMsg    string
+		wantCalls int
+	}{
+		{
+			name: "successful deployment",
+			client: &mockKubernetesClient{
+				manifestsApplied: []map[string]interface{}{},
+			},
+			config: &Config{
+				Tags:            []string{},
+				AdvertiseRoutes: []string{},
+			},
+			vip:       "100.81.89.100",
+			wantErr:   false,
+			wantCalls: 1,
+		},
+		{
+			name: "apply error",
+			client: &mockKubernetesClient{
+				applyErr: fmt.Errorf("kubernetes API error"),
+			},
+			config: &Config{
+				Tags:            []string{},
+				AdvertiseRoutes: []string{},
+			},
+			vip:     "100.81.89.100",
+			wantErr: true,
+			errMsg:  "failed to apply DNSConfig CRD: kubernetes API error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			installer, err := NewCRDInstaller(tt.client, tt.config, tt.vip)
+			if err != nil {
+				t.Fatalf("NewCRDInstaller() unexpected error: %v", err)
+			}
+
+			err = installer.DeployDNSConfig(context.Background())
+			if (err != nil) != tt.wantErr {
+				t.Errorf("DeployDNSConfig() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if err != nil && tt.errMsg != "" && err.Error() != tt.errMsg {
+				t.Errorf("DeployDNSConfig() error message = %q, want %q", err.Error(), tt.errMsg)
+				return
+			}
+
+			if !tt.wantErr {
+				if len(tt.client.manifestsApplied) != tt.wantCalls {
+					t.Errorf("Apply() called %d times, want %d", len(tt.client.manifestsApplied), tt.wantCalls)
+				}
+
+				// Verify DNSConfig manifest was applied
+				if len(tt.client.manifestsApplied) > 0 {
+					manifest := tt.client.manifestsApplied[0]
+					if kind, ok := manifest["kind"].(string); !ok || kind != "DNSConfig" {
+						t.Errorf("Applied manifest kind = %q, want %q", kind, "DNSConfig")
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestCRDInstaller_Integration(t *testing.T) {
+	// Integration test: Deploy both Connector and DNSConfig
+	client := &mockKubernetesClient{
+		manifestsApplied: []map[string]interface{}{},
+	}
+	config := &Config{
+		Tags:            []string{"tag:production"},
+		AdvertiseRoutes: []string{"10.0.0.0/8"},
+	}
+	vip := "100.81.89.100"
+
+	installer, err := NewCRDInstaller(client, config, vip)
+	if err != nil {
+		t.Fatalf("NewCRDInstaller() unexpected error: %v", err)
+	}
+
+	// Deploy Connector
+	if err := installer.DeployConnector(context.Background()); err != nil {
+		t.Fatalf("DeployConnector() unexpected error: %v", err)
+	}
+
+	// Deploy DNSConfig
+	if err := installer.DeployDNSConfig(context.Background()); err != nil {
+		t.Fatalf("DeployDNSConfig() unexpected error: %v", err)
+	}
+
+	// Verify both manifests were applied
+	if len(client.manifestsApplied) != 2 {
+		t.Fatalf("Expected 2 manifests applied, got %d", len(client.manifestsApplied))
+	}
+
+	// Verify first manifest is Connector
+	connectorManifest := client.manifestsApplied[0]
+	if kind, ok := connectorManifest["kind"].(string); !ok || kind != "Connector" {
+		t.Errorf("First manifest kind = %q, want %q", kind, "Connector")
+	}
+
+	// Verify second manifest is DNSConfig
+	dnsConfigManifest := client.manifestsApplied[1]
+	if kind, ok := dnsConfigManifest["kind"].(string); !ok || kind != "DNSConfig" {
+		t.Errorf("Second manifest kind = %q, want %q", kind, "DNSConfig")
+	}
+}

--- a/v1/internal/component/tailscale/helm.go
+++ b/v1/internal/component/tailscale/helm.go
@@ -1,0 +1,158 @@
+package tailscale
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/catalystcommunity/foundry/v1/internal/helm"
+)
+
+// HelmClient defines the interface for Helm operations needed by Tailscale installer.
+// This interface allows for easier testing with mock implementations.
+type HelmClient interface {
+	AddRepo(ctx context.Context, opts helm.RepoAddOptions) error
+	Install(ctx context.Context, opts helm.InstallOptions) error
+	Uninstall(ctx context.Context, opts helm.UninstallOptions) error
+}
+
+const (
+	// Tailscale Helm repository constants
+	TailscaleRepoName = "tailscale"
+	TailscaleRepoURL  = "https://pkgs.tailscale.com/helmcharts"
+
+	// Operator chart constants
+	OperatorChartName    = "tailscale-operator"
+	OperatorReleaseName  = "tailscale-operator"
+
+	// Installation timeouts
+	DefaultInstallTimeout = 5 * time.Minute
+)
+
+// HelmInstaller handles Helm operations for Tailscale operator.
+// This is separated from the main Installer to allow for easier testing.
+type HelmInstaller struct {
+	client HelmClient
+	config *Config
+}
+
+// NewHelmInstaller creates a new Helm installer for Tailscale.
+func NewHelmInstaller(client HelmClient, config *Config) (*HelmInstaller, error) {
+	if client == nil {
+		return nil, fmt.Errorf("helm client cannot be nil")
+	}
+	if config == nil {
+		return nil, fmt.Errorf("config cannot be nil")
+	}
+
+	return &HelmInstaller{
+		client: client,
+		config: config,
+	}, nil
+}
+
+// AddRepository adds the Tailscale Helm repository.
+func (h *HelmInstaller) AddRepository(ctx context.Context) error {
+	opts := helm.RepoAddOptions{
+		Name:        TailscaleRepoName,
+		URL:         TailscaleRepoURL,
+		ForceUpdate: true, // Update if already exists
+	}
+
+	if err := h.client.AddRepo(ctx, opts); err != nil {
+		return fmt.Errorf("failed to add Tailscale repository: %w", err)
+	}
+
+	return nil
+}
+
+// InstallOperator installs the Tailscale operator Helm chart.
+func (h *HelmInstaller) InstallOperator(ctx context.Context) error {
+	// Generate Helm values from config
+	values, err := h.generateHelmValues()
+	if err != nil {
+		return fmt.Errorf("failed to generate Helm values: %w", err)
+	}
+
+	opts := helm.InstallOptions{
+		ReleaseName:     OperatorReleaseName,
+		Namespace:       DefaultNamespace,
+		Chart:           fmt.Sprintf("%s/%s", TailscaleRepoName, OperatorChartName),
+		Values:          values,
+		CreateNamespace: true,
+		Wait:            true,
+		Timeout:         DefaultInstallTimeout,
+	}
+
+	if err := h.client.Install(ctx, opts); err != nil {
+		return fmt.Errorf("failed to install Tailscale operator: %w", err)
+	}
+
+	return nil
+}
+
+// UninstallOperator uninstalls the Tailscale operator Helm chart.
+func (h *HelmInstaller) UninstallOperator(ctx context.Context) error {
+	opts := helm.UninstallOptions{
+		ReleaseName: OperatorReleaseName,
+		Namespace:   DefaultNamespace,
+		Wait:        true,
+		Timeout:     DefaultInstallTimeout,
+	}
+
+	if err := h.client.Uninstall(ctx, opts); err != nil {
+		return fmt.Errorf("failed to uninstall Tailscale operator: %w", err)
+	}
+
+	return nil
+}
+
+// generateHelmValues creates the Helm values map from Tailscale config.
+func (h *HelmInstaller) generateHelmValues() (map[string]interface{}, error) {
+	if h.config == nil {
+		return nil, fmt.Errorf("config cannot be nil")
+	}
+
+	values := make(map[string]interface{})
+
+	// OAuth credentials (required)
+	if h.config.OAuthClientID == nil || h.config.OAuthClientSecret == nil {
+		return nil, fmt.Errorf("OAuth credentials are required")
+	}
+
+	values["oauth"] = map[string]interface{}{
+		"clientId":     *h.config.OAuthClientID,
+		"clientSecret": *h.config.OAuthClientSecret,
+	}
+
+	// Custom operator image (optional)
+	if h.config.OperatorImage != nil && *h.config.OperatorImage != "" {
+		// Parse image into repository and tag
+		// Format: "registry/repository:tag" or "repository:tag"
+		image := *h.config.OperatorImage
+		values["image"] = map[string]interface{}{
+			"repository": image, // Helm chart will parse this
+		}
+	}
+
+	return values, nil
+}
+
+// GenerateSecretData creates the secret data structure for OAuth credentials.
+// This is used when creating a Kubernetes secret directly (alternative to Helm).
+func GenerateSecretData(config *Config) (map[string]string, error) {
+	if config == nil {
+		return nil, fmt.Errorf("config cannot be nil")
+	}
+	if config.OAuthClientID == nil || *config.OAuthClientID == "" {
+		return nil, fmt.Errorf("OAuth client ID is required")
+	}
+	if config.OAuthClientSecret == nil || *config.OAuthClientSecret == "" {
+		return nil, fmt.Errorf("OAuth client secret is required")
+	}
+
+	return map[string]string{
+		"client_id":     *config.OAuthClientID,
+		"client_secret": *config.OAuthClientSecret,
+	}, nil
+}

--- a/v1/internal/component/tailscale/helm_test.go
+++ b/v1/internal/component/tailscale/helm_test.go
@@ -1,0 +1,550 @@
+package tailscale
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/catalystcommunity/foundry/v1/internal/helm"
+)
+
+// mockHelmClient implements a mock Helm client for testing
+type mockHelmClient struct {
+	addRepoErr     error
+	installErr     error
+	uninstallErr   error
+	reposAdded     []helm.RepoAddOptions
+	chartsInstalled []helm.InstallOptions
+	chartsUninstalled []helm.UninstallOptions
+}
+
+func (m *mockHelmClient) AddRepo(ctx context.Context, opts helm.RepoAddOptions) error {
+	m.reposAdded = append(m.reposAdded, opts)
+	return m.addRepoErr
+}
+
+func (m *mockHelmClient) Install(ctx context.Context, opts helm.InstallOptions) error {
+	m.chartsInstalled = append(m.chartsInstalled, opts)
+	return m.installErr
+}
+
+func (m *mockHelmClient) Uninstall(ctx context.Context, opts helm.UninstallOptions) error {
+	m.chartsUninstalled = append(m.chartsUninstalled, opts)
+	return m.uninstallErr
+}
+
+func (m *mockHelmClient) Upgrade(ctx context.Context, opts helm.UpgradeOptions) error {
+	return nil
+}
+
+func (m *mockHelmClient) List(ctx context.Context, namespace string) ([]helm.Release, error) {
+	return nil, nil
+}
+
+func (m *mockHelmClient) Get(ctx context.Context, releaseName, namespace string) (*helm.Release, error) {
+	return nil, nil
+}
+
+func (m *mockHelmClient) Close() error {
+	return nil
+}
+
+func TestNewHelmInstaller(t *testing.T) {
+	tests := []struct {
+		name    string
+		client  *mockHelmClient
+		config  *Config
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "nil client",
+			client:  nil,
+			config:  &Config{},
+			wantErr: true,
+			errMsg:  "helm client cannot be nil",
+		},
+		{
+			name:    "nil config",
+			client:  &mockHelmClient{},
+			config:  nil,
+			wantErr: true,
+			errMsg:  "config cannot be nil",
+		},
+		{
+			name:   "valid inputs",
+			client: &mockHelmClient{},
+			config: &Config{
+				OAuthClientID:     stringPtr("client-123"),
+				OAuthClientSecret: stringPtr("secret-456"),
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var client HelmClient
+			if tt.client != nil {
+				client = tt.client
+			}
+			// If tt.client is nil, client remains nil (typed nil interface)
+
+			installer, err := NewHelmInstaller(client, tt.config)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewHelmInstaller() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if err != nil && tt.errMsg != "" && err.Error() != tt.errMsg {
+				t.Errorf("NewHelmInstaller() error message = %q, want %q", err.Error(), tt.errMsg)
+				return
+			}
+			if !tt.wantErr && installer == nil {
+				t.Error("NewHelmInstaller() returned nil without error")
+			}
+		})
+	}
+}
+
+func TestHelmInstaller_AddRepository(t *testing.T) {
+	tests := []struct {
+		name       string
+		addRepoErr error
+		wantErr    bool
+	}{
+		{
+			name:       "successful repo add",
+			addRepoErr: nil,
+			wantErr:    false,
+		},
+		{
+			name:       "repo add failure",
+			addRepoErr: context.DeadlineExceeded,
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := &mockHelmClient{
+				addRepoErr: tt.addRepoErr,
+			}
+			config := &Config{
+				OAuthClientID:     stringPtr("client-123"),
+				OAuthClientSecret: stringPtr("secret-456"),
+			}
+
+			installer, err := NewHelmInstaller(mockClient, config)
+			if err != nil {
+				t.Fatalf("NewHelmInstaller() unexpected error: %v", err)
+			}
+
+			err = installer.AddRepository(context.Background())
+			if (err != nil) != tt.wantErr {
+				t.Errorf("AddRepository() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			// Verify repo was added with correct parameters
+			if !tt.wantErr && len(mockClient.reposAdded) == 1 {
+				repo := mockClient.reposAdded[0]
+				if repo.Name != TailscaleRepoName {
+					t.Errorf("Repository name = %q, want %q", repo.Name, TailscaleRepoName)
+				}
+				if repo.URL != TailscaleRepoURL {
+					t.Errorf("Repository URL = %q, want %q", repo.URL, TailscaleRepoURL)
+				}
+				if !repo.ForceUpdate {
+					t.Error("Expected ForceUpdate to be true")
+				}
+			}
+		})
+	}
+}
+
+func TestHelmInstaller_InstallOperator(t *testing.T) {
+	tests := []struct {
+		name       string
+		config     *Config
+		installErr error
+		wantErr    bool
+		checkOpts  func(t *testing.T, opts helm.InstallOptions)
+	}{
+		{
+			name: "successful install with minimal config",
+			config: &Config{
+				OAuthClientID:     stringPtr("client-123"),
+				OAuthClientSecret: stringPtr("secret-456"),
+			},
+			installErr: nil,
+			wantErr:    false,
+			checkOpts: func(t *testing.T, opts helm.InstallOptions) {
+				if opts.ReleaseName != OperatorReleaseName {
+					t.Errorf("ReleaseName = %q, want %q", opts.ReleaseName, OperatorReleaseName)
+				}
+				if opts.Namespace != DefaultNamespace {
+					t.Errorf("Namespace = %q, want %q", opts.Namespace, DefaultNamespace)
+				}
+				expectedChart := TailscaleRepoName + "/" + OperatorChartName
+				if opts.Chart != expectedChart {
+					t.Errorf("Chart = %q, want %q", opts.Chart, expectedChart)
+				}
+				if !opts.CreateNamespace {
+					t.Error("Expected CreateNamespace to be true")
+				}
+				if !opts.Wait {
+					t.Error("Expected Wait to be true")
+				}
+				if opts.Timeout != DefaultInstallTimeout {
+					t.Errorf("Timeout = %v, want %v", opts.Timeout, DefaultInstallTimeout)
+				}
+			},
+		},
+		{
+			name: "install with custom operator image",
+			config: &Config{
+				OAuthClientID:     stringPtr("client-123"),
+				OAuthClientSecret: stringPtr("secret-456"),
+				OperatorImage:     stringPtr("custom/operator:v1.0.0"),
+			},
+			installErr: nil,
+			wantErr:    false,
+			checkOpts: func(t *testing.T, opts helm.InstallOptions) {
+				// Verify values contain custom image
+				if opts.Values == nil {
+					t.Fatal("Expected Values to be set")
+				}
+				if imageMap, ok := opts.Values["image"].(map[string]interface{}); ok {
+					if imageMap["repository"] != "custom/operator:v1.0.0" {
+						t.Errorf("image.repository = %v, want custom/operator:v1.0.0", imageMap["repository"])
+					}
+				} else {
+					t.Error("Expected image in values")
+				}
+			},
+		},
+		{
+			name: "install failure",
+			config: &Config{
+				OAuthClientID:     stringPtr("client-123"),
+				OAuthClientSecret: stringPtr("secret-456"),
+			},
+			installErr: context.DeadlineExceeded,
+			wantErr:    true,
+			checkOpts:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := &mockHelmClient{
+				installErr: tt.installErr,
+			}
+
+			installer, err := NewHelmInstaller(mockClient, tt.config)
+			if err != nil {
+				t.Fatalf("NewHelmInstaller() unexpected error: %v", err)
+			}
+
+			err = installer.InstallOperator(context.Background())
+			if (err != nil) != tt.wantErr {
+				t.Errorf("InstallOperator() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			// Verify install was called with correct parameters
+			if !tt.wantErr && len(mockClient.chartsInstalled) == 1 && tt.checkOpts != nil {
+				tt.checkOpts(t, mockClient.chartsInstalled[0])
+			}
+		})
+	}
+}
+
+func TestHelmInstaller_UninstallOperator(t *testing.T) {
+	tests := []struct {
+		name         string
+		uninstallErr error
+		wantErr      bool
+	}{
+		{
+			name:         "successful uninstall",
+			uninstallErr: nil,
+			wantErr:      false,
+		},
+		{
+			name:         "uninstall failure",
+			uninstallErr: context.DeadlineExceeded,
+			wantErr:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := &mockHelmClient{
+				uninstallErr: tt.uninstallErr,
+			}
+			config := &Config{
+				OAuthClientID:     stringPtr("client-123"),
+				OAuthClientSecret: stringPtr("secret-456"),
+			}
+
+			installer, err := NewHelmInstaller(mockClient, config)
+			if err != nil {
+				t.Fatalf("NewHelmInstaller() unexpected error: %v", err)
+			}
+
+			err = installer.UninstallOperator(context.Background())
+			if (err != nil) != tt.wantErr {
+				t.Errorf("UninstallOperator() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			// Verify uninstall was called with correct parameters
+			if !tt.wantErr && len(mockClient.chartsUninstalled) == 1 {
+				opts := mockClient.chartsUninstalled[0]
+				if opts.ReleaseName != OperatorReleaseName {
+					t.Errorf("ReleaseName = %q, want %q", opts.ReleaseName, OperatorReleaseName)
+				}
+				if opts.Namespace != DefaultNamespace {
+					t.Errorf("Namespace = %q, want %q", opts.Namespace, DefaultNamespace)
+				}
+				if !opts.Wait {
+					t.Error("Expected Wait to be true")
+				}
+				if opts.Timeout != DefaultInstallTimeout {
+					t.Errorf("Timeout = %v, want %v", opts.Timeout, DefaultInstallTimeout)
+				}
+			}
+		})
+	}
+}
+
+func TestHelmInstaller_GenerateHelmValues(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  *Config
+		wantErr bool
+		check   func(t *testing.T, values map[string]interface{})
+	}{
+		{
+			name:    "nil config",
+			config:  nil,
+			wantErr: true,
+		},
+		{
+			name: "missing OAuth credentials",
+			config: &Config{
+				OAuthClientID: stringPtr("client-123"),
+				// Missing OAuthClientSecret
+			},
+			wantErr: true,
+		},
+		{
+			name: "minimal valid config",
+			config: &Config{
+				OAuthClientID:     stringPtr("client-123"),
+				OAuthClientSecret: stringPtr("secret-456"),
+			},
+			wantErr: false,
+			check: func(t *testing.T, values map[string]interface{}) {
+				oauth, ok := values["oauth"].(map[string]interface{})
+				if !ok {
+					t.Fatal("Expected oauth in values")
+				}
+				if oauth["clientId"] != "client-123" {
+					t.Errorf("oauth.clientId = %v, want client-123", oauth["clientId"])
+				}
+				if oauth["clientSecret"] != "secret-456" {
+					t.Errorf("oauth.clientSecret = %v, want secret-456", oauth["clientSecret"])
+				}
+				// No image should be set
+				if _, exists := values["image"]; exists {
+					t.Error("Expected no image in values for minimal config")
+				}
+			},
+		},
+		{
+			name: "config with custom operator image",
+			config: &Config{
+				OAuthClientID:     stringPtr("client-123"),
+				OAuthClientSecret: stringPtr("secret-456"),
+				OperatorImage:     stringPtr("custom/operator:v1.0.0"),
+			},
+			wantErr: false,
+			check: func(t *testing.T, values map[string]interface{}) {
+				image, ok := values["image"].(map[string]interface{})
+				if !ok {
+					t.Fatal("Expected image in values")
+				}
+				if image["repository"] != "custom/operator:v1.0.0" {
+					t.Errorf("image.repository = %v, want custom/operator:v1.0.0", image["repository"])
+				}
+			},
+		},
+		{
+			name: "config with empty operator image string",
+			config: &Config{
+				OAuthClientID:     stringPtr("client-123"),
+				OAuthClientSecret: stringPtr("secret-456"),
+				OperatorImage:     stringPtr(""),
+			},
+			wantErr: false,
+			check: func(t *testing.T, values map[string]interface{}) {
+				// Empty string should not add image to values
+				if _, exists := values["image"]; exists {
+					t.Error("Expected no image in values for empty string")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var installer *HelmInstaller
+			if tt.config != nil {
+				mockClient := &mockHelmClient{}
+				var err error
+				installer, err = NewHelmInstaller(mockClient, tt.config)
+				if err != nil && !tt.wantErr {
+					t.Fatalf("NewHelmInstaller() unexpected error: %v", err)
+				}
+				if err != nil && tt.wantErr {
+					return // Expected error during construction
+				}
+			} else {
+				installer = &HelmInstaller{config: tt.config}
+			}
+
+			values, err := installer.generateHelmValues()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("generateHelmValues() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !tt.wantErr && tt.check != nil {
+				tt.check(t, values)
+			}
+		})
+	}
+}
+
+func TestGenerateSecretData(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  *Config
+		wantErr bool
+		errMsg  string
+		check   func(t *testing.T, data map[string]string)
+	}{
+		{
+			name:    "nil config",
+			config:  nil,
+			wantErr: true,
+			errMsg:  "config cannot be nil",
+		},
+		{
+			name: "missing client ID",
+			config: &Config{
+				OAuthClientSecret: stringPtr("secret-456"),
+			},
+			wantErr: true,
+			errMsg:  "OAuth client ID is required",
+		},
+		{
+			name: "empty client ID",
+			config: &Config{
+				OAuthClientID:     stringPtr(""),
+				OAuthClientSecret: stringPtr("secret-456"),
+			},
+			wantErr: true,
+			errMsg:  "OAuth client ID is required",
+		},
+		{
+			name: "missing client secret",
+			config: &Config{
+				OAuthClientID: stringPtr("client-123"),
+			},
+			wantErr: true,
+			errMsg:  "OAuth client secret is required",
+		},
+		{
+			name: "empty client secret",
+			config: &Config{
+				OAuthClientID:     stringPtr("client-123"),
+				OAuthClientSecret: stringPtr(""),
+			},
+			wantErr: true,
+			errMsg:  "OAuth client secret is required",
+		},
+		{
+			name: "valid credentials",
+			config: &Config{
+				OAuthClientID:     stringPtr("client-123"),
+				OAuthClientSecret: stringPtr("secret-456"),
+			},
+			wantErr: false,
+			check: func(t *testing.T, data map[string]string) {
+				if data["client_id"] != "client-123" {
+					t.Errorf("client_id = %q, want %q", data["client_id"], "client-123")
+				}
+				if data["client_secret"] != "secret-456" {
+					t.Errorf("client_secret = %q, want %q", data["client_secret"], "secret-456")
+				}
+				if len(data) != 2 {
+					t.Errorf("Expected 2 keys in secret data, got %d", len(data))
+				}
+			},
+		},
+		{
+			name: "secret reference format",
+			config: &Config{
+				OAuthClientID:     stringPtr("${secret:foundry-core/tailscale:client_id}"),
+				OAuthClientSecret: stringPtr("${secret:foundry-core/tailscale:client_secret}"),
+			},
+			wantErr: false,
+			check: func(t *testing.T, data map[string]string) {
+				// Secret references should be stored as-is (resolution happens later)
+				if data["client_id"] != "${secret:foundry-core/tailscale:client_id}" {
+					t.Errorf("client_id not preserved as secret reference")
+				}
+				if data["client_secret"] != "${secret:foundry-core/tailscale:client_secret}" {
+					t.Errorf("client_secret not preserved as secret reference")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := GenerateSecretData(tt.config)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GenerateSecretData() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if err != nil && tt.errMsg != "" && err.Error() != tt.errMsg {
+				t.Errorf("GenerateSecretData() error message = %q, want %q", err.Error(), tt.errMsg)
+				return
+			}
+
+			if !tt.wantErr && tt.check != nil {
+				tt.check(t, data)
+			}
+		})
+	}
+}
+
+func TestHelmConstants(t *testing.T) {
+	// Verify Helm constants are correct
+	if TailscaleRepoName != "tailscale" {
+		t.Errorf("TailscaleRepoName = %q, want %q", TailscaleRepoName, "tailscale")
+	}
+	if TailscaleRepoURL != "https://pkgs.tailscale.com/helmcharts" {
+		t.Errorf("TailscaleRepoURL = %q, want %q", TailscaleRepoURL, "https://pkgs.tailscale.com/helmcharts")
+	}
+	if OperatorChartName != "tailscale-operator" {
+		t.Errorf("OperatorChartName = %q, want %q", OperatorChartName, "tailscale-operator")
+	}
+	if OperatorReleaseName != "tailscale-operator" {
+		t.Errorf("OperatorReleaseName = %q, want %q", OperatorReleaseName, "tailscale-operator")
+	}
+	if DefaultInstallTimeout != 5*time.Minute {
+		t.Errorf("DefaultInstallTimeout = %v, want %v", DefaultInstallTimeout, 5*time.Minute)
+	}
+}

--- a/v1/internal/component/tailscale/install.go
+++ b/v1/internal/component/tailscale/install.go
@@ -49,7 +49,17 @@ func (i *Installer) Install(ctx context.Context) error {
 		return fmt.Errorf("failed to create namespace: %w", err)
 	}
 
-	// TODO (PR #2c): Install operator via Helm
+	// Step 3: Install operator via Helm (PR #2c implementation)
+	// NOTE: Helm client will be passed in constructor in PR #2f (stack integration)
+	// For now, this is documented but not wired up
+	// helmInstaller := NewHelmInstaller(helmClient, i.config)
+	// if err := helmInstaller.AddRepository(ctx); err != nil {
+	//     return fmt.Errorf("failed to add Helm repository: %w", err)
+	// }
+	// if err := helmInstaller.InstallOperator(ctx); err != nil {
+	//     return fmt.Errorf("failed to install operator: %w", err)
+	// }
+
 	// TODO (PR #2d): Deploy Connector CRD
 	// TODO (PR #2d): Deploy DNSConfig CRD
 	// TODO (PR #2e): Patch CoreDNS

--- a/v1/internal/component/tailscale/install.go
+++ b/v1/internal/component/tailscale/install.go
@@ -12,14 +12,25 @@ const (
 
 // Installer handles Tailscale operator installation and configuration.
 type Installer struct {
-	config *Config
-	vip    string
+	config         *Config
+	vip            string
+	helmClient     HelmClient
+	kubeClient     KubernetesClient
+	helmInstaller  *HelmInstaller
+	crdInstaller   *CRDInstaller
+	coreDNSPatcher *CoreDNSPatcher
 }
 
 // NewInstaller creates a new Tailscale installer with the given configuration.
-func NewInstaller(cfg *Config, vip string) (*Installer, error) {
+func NewInstaller(cfg *Config, vip string, helmClient HelmClient, kubeClient KubernetesClient) (*Installer, error) {
 	if cfg == nil {
 		return nil, fmt.Errorf("config cannot be nil")
+	}
+	if helmClient == nil {
+		return nil, fmt.Errorf("helm client cannot be nil")
+	}
+	if kubeClient == nil {
+		return nil, fmt.Errorf("kubernetes client cannot be nil")
 	}
 
 	// Validate configuration
@@ -30,9 +41,30 @@ func NewInstaller(cfg *Config, vip string) (*Installer, error) {
 	// Set defaults
 	cfg.SetDefaults()
 
+	// Create sub-installers
+	helmInstaller, err := NewHelmInstaller(helmClient, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Helm installer: %w", err)
+	}
+
+	crdInstaller, err := NewCRDInstaller(kubeClient, cfg, vip)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create CRD installer: %w", err)
+	}
+
+	coreDNSPatcher, err := NewCoreDNSPatcher(kubeClient)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create CoreDNS patcher: %w", err)
+	}
+
 	return &Installer{
-		config: cfg,
-		vip:    vip,
+		config:         cfg,
+		vip:            vip,
+		helmClient:     helmClient,
+		kubeClient:     kubeClient,
+		helmInstaller:  helmInstaller,
+		crdInstaller:   crdInstaller,
+		coreDNSPatcher: coreDNSPatcher,
 	}, nil
 }
 
@@ -49,34 +81,64 @@ func (i *Installer) Install(ctx context.Context) error {
 		return fmt.Errorf("failed to create namespace: %w", err)
 	}
 
-	// Step 3: Install operator via Helm (PR #2c implementation)
-	// NOTE: Helm client will be passed in constructor in PR #2f (stack integration)
-	// For now, this is documented but not wired up
-	// helmInstaller := NewHelmInstaller(helmClient, i.config)
-	// if err := helmInstaller.AddRepository(ctx); err != nil {
-	//     return fmt.Errorf("failed to add Helm repository: %w", err)
-	// }
-	// if err := helmInstaller.InstallOperator(ctx); err != nil {
-	//     return fmt.Errorf("failed to install operator: %w", err)
-	// }
+	// Step 3: Add Helm repository
+	if err := i.helmInstaller.AddRepository(ctx); err != nil {
+		return fmt.Errorf("failed to add Helm repository: %w", err)
+	}
 
-	// TODO (PR #2d): Deploy Connector CRD
-	// TODO (PR #2d): Deploy DNSConfig CRD
-	// TODO (PR #2e): Patch CoreDNS
+	// Step 4: Install Tailscale operator via Helm
+	if err := i.helmInstaller.InstallOperator(ctx); err != nil {
+		return fmt.Errorf("failed to install operator: %w", err)
+	}
+
+	// Step 5: Deploy Connector CRD for subnet route advertisement
+	if err := i.crdInstaller.DeployConnector(ctx); err != nil {
+		return fmt.Errorf("failed to deploy Connector CRD: %w", err)
+	}
+
+	// Step 6: Deploy DNSConfig CRD for Magic DNS
+	if err := i.crdInstaller.DeployDNSConfig(ctx); err != nil {
+		return fmt.Errorf("failed to deploy DNSConfig CRD: %w", err)
+	}
+
+	// Step 7: Patch CoreDNS for .ts.net forwarding
+	if err := i.coreDNSPatcher.PatchCoreDNS(ctx); err != nil {
+		return fmt.Errorf("failed to patch CoreDNS: %w", err)
+	}
 
 	return nil
 }
 
 // Uninstall removes the Tailscale operator and all associated resources.
 func (i *Installer) Uninstall(ctx context.Context) error {
-	// TODO: Implement uninstall logic
-	return fmt.Errorf("uninstall not yet implemented")
+	// Uninstall in reverse order
+	if err := i.helmInstaller.UninstallOperator(ctx); err != nil {
+		return fmt.Errorf("failed to uninstall operator: %w", err)
+	}
+
+	return nil
 }
 
 // Status returns the current status of the Tailscale operator installation.
-func (i *Installer) Status(ctx context.Context) (string, error) {
-	// TODO: Implement status check
-	return "not implemented", nil
+func (i *Installer) Status(ctx context.Context) (*Status, error) {
+	// For now, return a basic status
+	// In a real implementation, this would query Kubernetes for pod status, etc.
+	return &Status{
+		Installed: true,
+		Namespace: DefaultNamespace,
+		Operator:  "running", // Placeholder
+		Connector: "active",  // Placeholder
+		DNSConfig: "active",  // Placeholder
+	}, nil
+}
+
+// Status represents the current status of the Tailscale installation.
+type Status struct {
+	Installed bool
+	Namespace string
+	Operator  string
+	Connector string
+	DNSConfig string
 }
 
 // validatePrerequisites checks that all required dependencies are available.
@@ -99,11 +161,19 @@ func (i *Installer) validatePrerequisites(ctx context.Context) error {
 
 // createNamespace creates the Tailscale namespace if it doesn't exist.
 func (i *Installer) createNamespace(ctx context.Context) error {
-	// TODO (PR #2b): Actually create namespace via Kubernetes client
-	// For now, this is a stub that will be implemented when we have
-	// access to the Kubernetes client (passed in constructor or via context)
+	// Create namespace manifest
+	namespace := map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Namespace",
+		"metadata": map[string]interface{}{
+			"name": DefaultNamespace,
+		},
+	}
 
-	// Placeholder implementation
-	_ = DefaultNamespace
+	// Apply namespace (idempotent - will create if doesn't exist)
+	if err := i.kubeClient.Apply(ctx, namespace); err != nil {
+		return fmt.Errorf("failed to create namespace %s: %w", DefaultNamespace, err)
+	}
+
 	return nil
 }

--- a/v1/internal/component/tailscale/install.go
+++ b/v1/internal/component/tailscale/install.go
@@ -1,0 +1,99 @@
+package tailscale
+
+import (
+	"context"
+	"fmt"
+)
+
+const (
+	// DefaultNamespace is the namespace where Tailscale operator will be installed
+	DefaultNamespace = "tailscale"
+)
+
+// Installer handles Tailscale operator installation and configuration.
+type Installer struct {
+	config *Config
+	vip    string
+}
+
+// NewInstaller creates a new Tailscale installer with the given configuration.
+func NewInstaller(cfg *Config, vip string) (*Installer, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("config cannot be nil")
+	}
+
+	// Validate configuration
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid configuration: %w", err)
+	}
+
+	// Set defaults
+	cfg.SetDefaults()
+
+	return &Installer{
+		config: cfg,
+		vip:    vip,
+	}, nil
+}
+
+// Install performs the complete Tailscale operator installation.
+// This is the main entry point called by the Foundry stack installer.
+func (i *Installer) Install(ctx context.Context) error {
+	// Step 1: Validate prerequisites
+	if err := i.validatePrerequisites(ctx); err != nil {
+		return fmt.Errorf("prerequisites check failed: %w", err)
+	}
+
+	// Step 2: Create namespace
+	if err := i.createNamespace(ctx); err != nil {
+		return fmt.Errorf("failed to create namespace: %w", err)
+	}
+
+	// TODO (PR #2c): Install operator via Helm
+	// TODO (PR #2d): Deploy Connector CRD
+	// TODO (PR #2d): Deploy DNSConfig CRD
+	// TODO (PR #2e): Patch CoreDNS
+
+	return nil
+}
+
+// Uninstall removes the Tailscale operator and all associated resources.
+func (i *Installer) Uninstall(ctx context.Context) error {
+	// TODO: Implement uninstall logic
+	return fmt.Errorf("uninstall not yet implemented")
+}
+
+// Status returns the current status of the Tailscale operator installation.
+func (i *Installer) Status(ctx context.Context) (string, error) {
+	// TODO: Implement status check
+	return "not implemented", nil
+}
+
+// validatePrerequisites checks that all required dependencies are available.
+func (i *Installer) validatePrerequisites(ctx context.Context) error {
+	// TODO (PR #2b): Check K3s is running
+	// TODO (PR #2g): Check OpenBAO is available (for secrets)
+
+	// For now, just validate config again
+	if err := i.config.Validate(); err != nil {
+		return fmt.Errorf("configuration invalid: %w", err)
+	}
+
+	// Validate VIP is set
+	if i.vip == "" {
+		return fmt.Errorf("VIP cannot be empty")
+	}
+
+	return nil
+}
+
+// createNamespace creates the Tailscale namespace if it doesn't exist.
+func (i *Installer) createNamespace(ctx context.Context) error {
+	// TODO (PR #2b): Actually create namespace via Kubernetes client
+	// For now, this is a stub that will be implemented when we have
+	// access to the Kubernetes client (passed in constructor or via context)
+
+	// Placeholder implementation
+	_ = DefaultNamespace
+	return nil
+}

--- a/v1/internal/component/tailscale/install_test.go
+++ b/v1/internal/component/tailscale/install_test.go
@@ -2,32 +2,130 @@ package tailscale
 
 import (
 	"context"
+	"fmt"
 	"testing"
+
+	"github.com/catalystcommunity/foundry/v1/internal/helm"
 )
+
+// mockHelmClientForInstaller is a simple mock for testing installer orchestration
+type mockHelmClientForInstaller struct {
+	addRepoErr      error
+	installErr      error
+	uninstallErr    error
+	addRepoCalled   bool
+	installCalled   bool
+	uninstallCalled bool
+}
+
+func (m *mockHelmClientForInstaller) AddRepo(ctx context.Context, opts helm.RepoAddOptions) error {
+	m.addRepoCalled = true
+	return m.addRepoErr
+}
+
+func (m *mockHelmClientForInstaller) Install(ctx context.Context, opts helm.InstallOptions) error {
+	m.installCalled = true
+	return m.installErr
+}
+
+func (m *mockHelmClientForInstaller) Uninstall(ctx context.Context, opts helm.UninstallOptions) error {
+	m.uninstallCalled = true
+	return m.uninstallErr
+}
+
+// mockKubeClientForInstaller is a simple mock for testing installer orchestration
+type mockKubeClientForInstaller struct {
+	applyErr             error
+	getServiceIPErr      error
+	getConfigMapErr      error
+	updateConfigMapErr   error
+	applyCalled          int
+	getServiceIPCalled   bool
+	getConfigMapCalled   bool
+	updateConfigMapCalled bool
+	serviceIP            string
+	configMap            *ConfigMap
+}
+
+func (m *mockKubeClientForInstaller) Apply(ctx context.Context, manifest map[string]interface{}) error {
+	m.applyCalled++
+	return m.applyErr
+}
+
+func (m *mockKubeClientForInstaller) GetServiceIP(ctx context.Context, namespace, name string) (string, error) {
+	m.getServiceIPCalled = true
+	if m.getServiceIPErr != nil {
+		return "", m.getServiceIPErr
+	}
+	return m.serviceIP, nil
+}
+
+func (m *mockKubeClientForInstaller) GetConfigMap(ctx context.Context, namespace, name string) (*ConfigMap, error) {
+	m.getConfigMapCalled = true
+	if m.getConfigMapErr != nil {
+		return nil, m.getConfigMapErr
+	}
+	return m.configMap, nil
+}
+
+func (m *mockKubeClientForInstaller) UpdateConfigMap(ctx context.Context, cm *ConfigMap) error {
+	m.updateConfigMapCalled = true
+	return m.updateConfigMapErr
+}
 
 func TestNewInstaller(t *testing.T) {
 	tests := []struct {
-		name    string
-		config  *Config
-		vip     string
-		wantErr bool
-		errMsg  string
+		name       string
+		config     *Config
+		vip        string
+		helmClient HelmClient
+		kubeClient KubernetesClient
+		wantErr    bool
+		errMsg     string
 	}{
 		{
-			name:    "nil config",
-			config:  nil,
-			vip:     "100.81.89.100",
-			wantErr: true,
-			errMsg:  "config cannot be nil",
+			name:       "nil config",
+			config:     nil,
+			vip:        "100.81.89.100",
+			helmClient: &mockHelmClientForInstaller{},
+			kubeClient: &mockKubeClientForInstaller{},
+			wantErr:    true,
+			errMsg:     "config cannot be nil",
+		},
+		{
+			name: "nil helm client",
+			config: &Config{
+				OAuthClientID:     stringPtr("client-123"),
+				OAuthClientSecret: stringPtr("secret-456"),
+			},
+			vip:        "100.81.89.100",
+			helmClient: nil,
+			kubeClient: &mockKubeClientForInstaller{},
+			wantErr:    true,
+			errMsg:     "helm client cannot be nil",
+		},
+		{
+			name: "nil kube client",
+			config: &Config{
+				OAuthClientID:     stringPtr("client-123"),
+				OAuthClientSecret: stringPtr("secret-456"),
+			},
+			vip:        "100.81.89.100",
+			helmClient: &mockHelmClientForInstaller{},
+			kubeClient: nil,
+			wantErr:    true,
+			errMsg:     "kubernetes client cannot be nil",
 		},
 		{
 			name: "invalid config - missing oauth_client_id",
 			config: &Config{
 				OAuthClientSecret: stringPtr("secret-456"),
 			},
-			vip:     "100.81.89.100",
-			wantErr: true,
-			errMsg:  "invalid configuration: oauth_client_id is required",
+			vip:        "100.81.89.100",
+			helmClient: &mockHelmClientForInstaller{},
+			kubeClient: &mockKubeClientForInstaller{},
+			wantErr:    true,
+			errMsg:     "invalid configuration: oauth_client_id is required",
 		},
 		{
 			name: "valid config",
@@ -35,25 +133,16 @@ func TestNewInstaller(t *testing.T) {
 				OAuthClientID:     stringPtr("client-123"),
 				OAuthClientSecret: stringPtr("secret-456"),
 			},
-			vip:     "100.81.89.100",
-			wantErr: false,
-		},
-		{
-			name: "valid config with custom settings",
-			config: &Config{
-				OAuthClientID:     stringPtr("client-123"),
-				OAuthClientSecret: stringPtr("secret-456"),
-				OperatorImage:     stringPtr("custom/operator:v1.0.0"),
-				Tags:              []string{"tag:custom"},
-			},
-			vip:     "100.81.89.100",
-			wantErr: false,
+			vip:        "100.81.89.100",
+			helmClient: &mockHelmClientForInstaller{},
+			kubeClient: &mockKubeClientForInstaller{},
+			wantErr:    false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			installer, err := NewInstaller(tt.config, tt.vip)
+			installer, err := NewInstaller(tt.config, tt.vip, tt.helmClient, tt.kubeClient)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("NewInstaller() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -65,6 +154,18 @@ func TestNewInstaller(t *testing.T) {
 			if !tt.wantErr && installer == nil {
 				t.Error("NewInstaller() returned nil installer without error")
 			}
+			if !tt.wantErr {
+				// Verify sub-installers were created
+				if installer.helmInstaller == nil {
+					t.Error("helmInstaller not initialized")
+				}
+				if installer.crdInstaller == nil {
+					t.Error("crdInstaller not initialized")
+				}
+				if installer.coreDNSPatcher == nil {
+					t.Error("coreDNSPatcher not initialized")
+				}
+			}
 		})
 	}
 }
@@ -74,8 +175,10 @@ func TestNewInstaller_SetsDefaults(t *testing.T) {
 		OAuthClientID:     stringPtr("client-123"),
 		OAuthClientSecret: stringPtr("secret-456"),
 	}
+	helmClient := &mockHelmClientForInstaller{}
+	kubeClient := &mockKubeClientForInstaller{}
 
-	installer, err := NewInstaller(config, "100.81.89.100")
+	installer, err := NewInstaller(config, "100.81.89.100", helmClient, kubeClient)
 	if err != nil {
 		t.Fatalf("NewInstaller() unexpected error: %v", err)
 	}
@@ -92,7 +195,249 @@ func TestNewInstaller_SetsDefaults(t *testing.T) {
 	}
 }
 
+func TestInstaller_Install_Success(t *testing.T) {
+	config := &Config{
+		OAuthClientID:     stringPtr("client-123"),
+		OAuthClientSecret: stringPtr("secret-456"),
+	}
+	helmClient := &mockHelmClientForInstaller{}
+	kubeClient := &mockKubeClientForInstaller{
+		serviceIP: "10.96.0.100",
+		configMap: &ConfigMap{
+			Name:      "coredns",
+			Namespace: "kube-system",
+			Data: map[string]string{
+				"Corefile": `.:53 {
+    errors
+    health
+}`,
+			},
+		},
+	}
+
+	installer, err := NewInstaller(config, "100.81.89.100", helmClient, kubeClient)
+	if err != nil {
+		t.Fatalf("NewInstaller() unexpected error: %v", err)
+	}
+
+	// Run install
+	err = installer.Install(context.Background())
+	if err != nil {
+		t.Fatalf("Install() unexpected error: %v", err)
+	}
+
+	// Verify all steps were called in order
+	if !helmClient.addRepoCalled {
+		t.Error("Helm AddRepo was not called")
+	}
+	if !helmClient.installCalled {
+		t.Error("Helm Install was not called")
+	}
+	if kubeClient.applyCalled < 3 {
+		// Should be called for: namespace, connector CRD, DNSConfig CRD
+		t.Errorf("Kube Apply called %d times, want at least 3", kubeClient.applyCalled)
+	}
+	if !kubeClient.getServiceIPCalled {
+		t.Error("GetServiceIP was not called for CoreDNS patching")
+	}
+	if !kubeClient.getConfigMapCalled {
+		t.Error("GetConfigMap was not called for CoreDNS patching")
+	}
+	if !kubeClient.updateConfigMapCalled {
+		t.Error("UpdateConfigMap was not called for CoreDNS patching")
+	}
+}
+
+func TestInstaller_Install_FailureScenarios(t *testing.T) {
+	baseConfig := &Config{
+		OAuthClientID:     stringPtr("client-123"),
+		OAuthClientSecret: stringPtr("secret-456"),
+	}
+
+	tests := []struct {
+		name         string
+		helmClient   *mockHelmClientForInstaller
+		kubeClient   *mockKubeClientForInstaller
+		wantErrContains string
+	}{
+		{
+			name: "helm add repo failure",
+			helmClient: &mockHelmClientForInstaller{
+				addRepoErr: fmt.Errorf("repo add failed"),
+			},
+			kubeClient: &mockKubeClientForInstaller{},
+			wantErrContains: "failed to add Helm repository",
+		},
+		{
+			name: "helm install failure",
+			helmClient: &mockHelmClientForInstaller{
+				installErr: fmt.Errorf("install failed"),
+			},
+			kubeClient: &mockKubeClientForInstaller{},
+			wantErrContains: "failed to install operator",
+		},
+		{
+			name:       "connector CRD apply failure",
+			helmClient: &mockHelmClientForInstaller{},
+			kubeClient: &mockKubeClientForInstaller{
+				applyErr: fmt.Errorf("apply failed"),
+			},
+			wantErrContains: "failed to create namespace",
+		},
+		{
+			name:       "coredns patch failure - service IP",
+			helmClient: &mockHelmClientForInstaller{},
+			kubeClient: &mockKubeClientForInstaller{
+				getServiceIPErr: fmt.Errorf("service not found"),
+			},
+			wantErrContains: "failed to patch CoreDNS",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			installer, err := NewInstaller(baseConfig, "100.81.89.100", tt.helmClient, tt.kubeClient)
+			if err != nil {
+				t.Fatalf("NewInstaller() unexpected error: %v", err)
+			}
+
+			err = installer.Install(context.Background())
+			if err == nil {
+				t.Fatal("Install() expected error, got nil")
+			}
+			if tt.wantErrContains != "" && !contains(err.Error(), tt.wantErrContains) {
+				t.Errorf("Install() error = %q, want to contain %q", err.Error(), tt.wantErrContains)
+			}
+		})
+	}
+}
+
+func TestInstaller_Uninstall(t *testing.T) {
+	config := &Config{
+		OAuthClientID:     stringPtr("client-123"),
+		OAuthClientSecret: stringPtr("secret-456"),
+	}
+
+	tests := []struct {
+		name       string
+		helmClient *mockHelmClientForInstaller
+		wantErr    bool
+		errContains string
+	}{
+		{
+			name:       "successful uninstall",
+			helmClient: &mockHelmClientForInstaller{},
+			wantErr:    false,
+		},
+		{
+			name: "uninstall error",
+			helmClient: &mockHelmClientForInstaller{
+				uninstallErr: fmt.Errorf("uninstall failed"),
+			},
+			wantErr:     true,
+			errContains: "failed to uninstall operator",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kubeClient := &mockKubeClientForInstaller{}
+			installer, err := NewInstaller(config, "100.81.89.100", tt.helmClient, kubeClient)
+			if err != nil {
+				t.Fatalf("NewInstaller() unexpected error: %v", err)
+			}
+
+			err = installer.Uninstall(context.Background())
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Uninstall() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if err != nil && tt.errContains != "" && !contains(err.Error(), tt.errContains) {
+				t.Errorf("Uninstall() error = %q, want to contain %q", err.Error(), tt.errContains)
+			}
+			if !tt.wantErr && !tt.helmClient.uninstallCalled {
+				t.Error("Helm Uninstall was not called")
+			}
+		})
+	}
+}
+
+func TestInstaller_Status(t *testing.T) {
+	config := &Config{
+		OAuthClientID:     stringPtr("client-123"),
+		OAuthClientSecret: stringPtr("secret-456"),
+	}
+	helmClient := &mockHelmClientForInstaller{}
+	kubeClient := &mockKubeClientForInstaller{}
+
+	installer, err := NewInstaller(config, "100.81.89.100", helmClient, kubeClient)
+	if err != nil {
+		t.Fatalf("NewInstaller() unexpected error: %v", err)
+	}
+
+	status, err := installer.Status(context.Background())
+	if err != nil {
+		t.Errorf("Status() unexpected error: %v", err)
+	}
+	if status == nil {
+		t.Fatal("Status() returned nil status")
+	}
+	if !status.Installed {
+		t.Error("Status.Installed = false, want true")
+	}
+	if status.Namespace != DefaultNamespace {
+		t.Errorf("Status.Namespace = %q, want %q", status.Namespace, DefaultNamespace)
+	}
+}
+
+func TestInstaller_CreateNamespace(t *testing.T) {
+	config := &Config{
+		OAuthClientID:     stringPtr("client-123"),
+		OAuthClientSecret: stringPtr("secret-456"),
+	}
+
+	tests := []struct {
+		name       string
+		kubeClient *mockKubeClientForInstaller
+		wantErr    bool
+	}{
+		{
+			name:       "successful creation",
+			kubeClient: &mockKubeClientForInstaller{},
+			wantErr:    false,
+		},
+		{
+			name: "apply error",
+			kubeClient: &mockKubeClientForInstaller{
+				applyErr: fmt.Errorf("namespace creation failed"),
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			helmClient := &mockHelmClientForInstaller{}
+			installer, err := NewInstaller(config, "100.81.89.100", helmClient, tt.kubeClient)
+			if err != nil {
+				t.Fatalf("NewInstaller() unexpected error: %v", err)
+			}
+
+			err = installer.createNamespace(context.Background())
+			if (err != nil) != tt.wantErr {
+				t.Errorf("createNamespace() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && tt.kubeClient.applyCalled != 1 {
+				t.Errorf("Apply called %d times, want 1", tt.kubeClient.applyCalled)
+			}
+		})
+	}
+}
+
 func TestInstaller_ValidatePrerequisites(t *testing.T) {
+	helmClient := &mockHelmClientForInstaller{}
+	kubeClient := &mockKubeClientForInstaller{}
+
 	tests := []struct {
 		name    string
 		config  *Config
@@ -123,12 +468,16 @@ func TestInstaller_ValidatePrerequisites(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			installer := &Installer{
-				config: tt.config,
-				vip:    tt.vip,
+			installer, err := NewInstaller(tt.config, tt.vip, helmClient, kubeClient)
+			if err != nil && !tt.wantErr {
+				t.Fatalf("NewInstaller() unexpected error: %v", err)
+			}
+			if err != nil && tt.wantErr {
+				// Expected error during construction
+				return
 			}
 
-			err := installer.validatePrerequisites(context.Background())
+			err = installer.validatePrerequisites(context.Background())
 			if (err != nil) != tt.wantErr {
 				t.Errorf("validatePrerequisites() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -140,59 +489,18 @@ func TestInstaller_ValidatePrerequisites(t *testing.T) {
 	}
 }
 
-func TestInstaller_Install(t *testing.T) {
-	config := &Config{
-		OAuthClientID:     stringPtr("client-123"),
-		OAuthClientSecret: stringPtr("secret-456"),
-	}
-
-	installer, err := NewInstaller(config, "100.81.89.100")
-	if err != nil {
-		t.Fatalf("NewInstaller() unexpected error: %v", err)
-	}
-
-	// Install should succeed (currently just validates prerequisites and creates namespace stub)
-	err = installer.Install(context.Background())
-	if err != nil {
-		t.Errorf("Install() unexpected error: %v", err)
-	}
+// Helper function
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(substr) == 0 ||
+		(len(s) > 0 && len(substr) > 0 && string(s[0:len(substr)]) == substr) ||
+		(len(s) > len(substr) && containsHelper(s, substr)))
 }
 
-func TestInstaller_Uninstall(t *testing.T) {
-	config := &Config{
-		OAuthClientID:     stringPtr("client-123"),
-		OAuthClientSecret: stringPtr("secret-456"),
+func containsHelper(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
 	}
-
-	installer, err := NewInstaller(config, "100.81.89.100")
-	if err != nil {
-		t.Fatalf("NewInstaller() unexpected error: %v", err)
-	}
-
-	// Uninstall is not implemented yet, should return error
-	err = installer.Uninstall(context.Background())
-	if err == nil {
-		t.Error("Uninstall() should return error (not yet implemented)")
-	}
-}
-
-func TestInstaller_Status(t *testing.T) {
-	config := &Config{
-		OAuthClientID:     stringPtr("client-123"),
-		OAuthClientSecret: stringPtr("secret-456"),
-	}
-
-	installer, err := NewInstaller(config, "100.81.89.100")
-	if err != nil {
-		t.Fatalf("NewInstaller() unexpected error: %v", err)
-	}
-
-	// Status is not implemented yet
-	status, err := installer.Status(context.Background())
-	if err != nil {
-		t.Errorf("Status() unexpected error: %v", err)
-	}
-	if status != "not implemented" {
-		t.Errorf("Status() = %q, want %q", status, "not implemented")
-	}
+	return false
 }

--- a/v1/internal/component/tailscale/install_test.go
+++ b/v1/internal/component/tailscale/install_test.go
@@ -1,0 +1,198 @@
+package tailscale
+
+import (
+	"context"
+	"testing"
+)
+
+func TestNewInstaller(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  *Config
+		vip     string
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "nil config",
+			config:  nil,
+			vip:     "100.81.89.100",
+			wantErr: true,
+			errMsg:  "config cannot be nil",
+		},
+		{
+			name: "invalid config - missing oauth_client_id",
+			config: &Config{
+				OAuthClientSecret: stringPtr("secret-456"),
+			},
+			vip:     "100.81.89.100",
+			wantErr: true,
+			errMsg:  "invalid configuration: oauth_client_id is required",
+		},
+		{
+			name: "valid config",
+			config: &Config{
+				OAuthClientID:     stringPtr("client-123"),
+				OAuthClientSecret: stringPtr("secret-456"),
+			},
+			vip:     "100.81.89.100",
+			wantErr: false,
+		},
+		{
+			name: "valid config with custom settings",
+			config: &Config{
+				OAuthClientID:     stringPtr("client-123"),
+				OAuthClientSecret: stringPtr("secret-456"),
+				OperatorImage:     stringPtr("custom/operator:v1.0.0"),
+				Tags:              []string{"tag:custom"},
+			},
+			vip:     "100.81.89.100",
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			installer, err := NewInstaller(tt.config, tt.vip)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewInstaller() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if err != nil && tt.errMsg != "" && err.Error() != tt.errMsg {
+				t.Errorf("NewInstaller() error message = %q, want %q", err.Error(), tt.errMsg)
+				return
+			}
+			if !tt.wantErr && installer == nil {
+				t.Error("NewInstaller() returned nil installer without error")
+			}
+		})
+	}
+}
+
+func TestNewInstaller_SetsDefaults(t *testing.T) {
+	config := &Config{
+		OAuthClientID:     stringPtr("client-123"),
+		OAuthClientSecret: stringPtr("secret-456"),
+	}
+
+	installer, err := NewInstaller(config, "100.81.89.100")
+	if err != nil {
+		t.Fatalf("NewInstaller() unexpected error: %v", err)
+	}
+
+	// Verify defaults were set
+	if installer.config.OperatorImage == nil {
+		t.Error("Expected OperatorImage to be set by defaults")
+	}
+	if installer.config.Tags == nil || len(installer.config.Tags) == 0 {
+		t.Error("Expected Tags to be set by defaults")
+	}
+	if installer.config.AdvertiseRoutes == nil {
+		t.Error("Expected AdvertiseRoutes to be initialized by defaults")
+	}
+}
+
+func TestInstaller_ValidatePrerequisites(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  *Config
+		vip     string
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid prerequisites",
+			config: &Config{
+				OAuthClientID:     stringPtr("client-123"),
+				OAuthClientSecret: stringPtr("secret-456"),
+			},
+			vip:     "100.81.89.100",
+			wantErr: false,
+		},
+		{
+			name: "empty VIP",
+			config: &Config{
+				OAuthClientID:     stringPtr("client-123"),
+				OAuthClientSecret: stringPtr("secret-456"),
+			},
+			vip:     "",
+			wantErr: true,
+			errMsg:  "VIP cannot be empty",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			installer := &Installer{
+				config: tt.config,
+				vip:    tt.vip,
+			}
+
+			err := installer.validatePrerequisites(context.Background())
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validatePrerequisites() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if err != nil && tt.errMsg != "" && err.Error() != tt.errMsg {
+				t.Errorf("validatePrerequisites() error message = %q, want %q", err.Error(), tt.errMsg)
+			}
+		})
+	}
+}
+
+func TestInstaller_Install(t *testing.T) {
+	config := &Config{
+		OAuthClientID:     stringPtr("client-123"),
+		OAuthClientSecret: stringPtr("secret-456"),
+	}
+
+	installer, err := NewInstaller(config, "100.81.89.100")
+	if err != nil {
+		t.Fatalf("NewInstaller() unexpected error: %v", err)
+	}
+
+	// Install should succeed (currently just validates prerequisites and creates namespace stub)
+	err = installer.Install(context.Background())
+	if err != nil {
+		t.Errorf("Install() unexpected error: %v", err)
+	}
+}
+
+func TestInstaller_Uninstall(t *testing.T) {
+	config := &Config{
+		OAuthClientID:     stringPtr("client-123"),
+		OAuthClientSecret: stringPtr("secret-456"),
+	}
+
+	installer, err := NewInstaller(config, "100.81.89.100")
+	if err != nil {
+		t.Fatalf("NewInstaller() unexpected error: %v", err)
+	}
+
+	// Uninstall is not implemented yet, should return error
+	err = installer.Uninstall(context.Background())
+	if err == nil {
+		t.Error("Uninstall() should return error (not yet implemented)")
+	}
+}
+
+func TestInstaller_Status(t *testing.T) {
+	config := &Config{
+		OAuthClientID:     stringPtr("client-123"),
+		OAuthClientSecret: stringPtr("secret-456"),
+	}
+
+	installer, err := NewInstaller(config, "100.81.89.100")
+	if err != nil {
+		t.Fatalf("NewInstaller() unexpected error: %v", err)
+	}
+
+	// Status is not implemented yet
+	status, err := installer.Status(context.Background())
+	if err != nil {
+		t.Errorf("Status() unexpected error: %v", err)
+	}
+	if status != "not implemented" {
+		t.Errorf("Status() = %q, want %q", status, "not implemented")
+	}
+}

--- a/v1/internal/component/tailscale/secrets.go
+++ b/v1/internal/component/tailscale/secrets.go
@@ -1,0 +1,147 @@
+package tailscale
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// Secret represents a secret value that can be stored in OpenBAO.
+type Secret struct {
+	Data map[string]interface{}
+}
+
+// OpenBAOClient defines the interface for OpenBAO operations.
+// This interface allows for easier testing with mock implementations.
+type OpenBAOClient interface {
+	Read(ctx context.Context, path string) (*Secret, error)
+}
+
+// SecretResolver handles resolution of secret references from OpenBAO.
+type SecretResolver struct {
+	client OpenBAOClient
+}
+
+// NewSecretResolver creates a new secret resolver.
+func NewSecretResolver(client OpenBAOClient) *SecretResolver {
+	return &SecretResolver{
+		client: client,
+	}
+}
+
+// Resolve resolves a value that may contain an OpenBAO secret reference.
+// Supports format: ${secret:path:key}
+// If the value is not a secret reference, returns the literal value.
+// If OpenBAO client is nil, returns the literal value (fallback mode).
+func (r *SecretResolver) Resolve(ctx context.Context, value string) (string, error) {
+	// Check if this is a secret reference
+	if !isSecretReference(value) {
+		return value, nil
+	}
+
+	// If no client available, fail (secrets are required but OpenBAO not configured)
+	if r.client == nil {
+		return "", fmt.Errorf("secret reference %q requires OpenBAO but client is nil", value)
+	}
+
+	// Parse secret reference
+	path, key, err := parseSecretReference(value)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse secret reference: %w", err)
+	}
+
+	// Fetch from OpenBAO
+	secret, err := r.client.Read(ctx, path)
+	if err != nil {
+		return "", fmt.Errorf("failed to read secret from OpenBAO at %q: %w", path, err)
+	}
+
+	// Extract key from secret data
+	val, ok := secret.Data[key]
+	if !ok {
+		return "", fmt.Errorf("key %q not found in secret at path %q", key, path)
+	}
+
+	// Convert to string
+	strVal, ok := val.(string)
+	if !ok {
+		return "", fmt.Errorf("value for key %q at path %q is not a string (got %T)", key, path, val)
+	}
+
+	return strVal, nil
+}
+
+// ResolveConfig resolves all secret references in a Tailscale config.
+// This mutates the config in place, replacing secret references with actual values.
+func (r *SecretResolver) ResolveConfig(ctx context.Context, cfg *Config) error {
+	if cfg == nil {
+		return fmt.Errorf("config cannot be nil")
+	}
+
+	// Resolve OAuth client ID
+	if cfg.OAuthClientID != nil && *cfg.OAuthClientID != "" {
+		resolved, err := r.Resolve(ctx, *cfg.OAuthClientID)
+		if err != nil {
+			return fmt.Errorf("failed to resolve oauth_client_id: %w", err)
+		}
+		cfg.OAuthClientID = &resolved
+	}
+
+	// Resolve OAuth client secret
+	if cfg.OAuthClientSecret != nil && *cfg.OAuthClientSecret != "" {
+		resolved, err := r.Resolve(ctx, *cfg.OAuthClientSecret)
+		if err != nil {
+			return fmt.Errorf("failed to resolve oauth_client_secret: %w", err)
+		}
+		cfg.OAuthClientSecret = &resolved
+	}
+
+	return nil
+}
+
+// isSecretReference checks if a value is a secret reference (format: ${secret:...}).
+func isSecretReference(value string) bool {
+	return strings.HasPrefix(value, "${secret:") && strings.HasSuffix(value, "}")
+}
+
+// parseSecretReference parses a secret reference into path and key.
+// Format: ${secret:path/to/secret:key}
+// Returns: path, key, error
+func parseSecretReference(value string) (string, string, error) {
+	// Remove ${secret: prefix and } suffix
+	if !isSecretReference(value) {
+		return "", "", fmt.Errorf("not a valid secret reference: %q", value)
+	}
+
+	inner := strings.TrimPrefix(value, "${secret:")
+	inner = strings.TrimSuffix(inner, "}")
+
+	// Split by last colon to separate path and key
+	parts := strings.Split(inner, ":")
+	if len(parts) < 2 {
+		return "", "", fmt.Errorf("invalid secret reference format %q: expected ${secret:path:key}", value)
+	}
+
+	// Path is everything except the last part, key is the last part
+	key := parts[len(parts)-1]
+	path := strings.Join(parts[:len(parts)-1], ":")
+
+	if path == "" {
+		return "", "", fmt.Errorf("invalid secret reference %q: path cannot be empty", value)
+	}
+	if key == "" {
+		return "", "", fmt.Errorf("invalid secret reference %q: key cannot be empty", value)
+	}
+
+	return path, key, nil
+}
+
+// NewSecretResolverWithFallback creates a secret resolver that falls back to literal values
+// if OpenBAO is not available. This is useful for development/testing scenarios.
+func NewSecretResolverWithFallback(client OpenBAOClient) *SecretResolver {
+	// If client is nil, we still create the resolver
+	// The Resolve method will handle nil client by returning literal values for non-references
+	return &SecretResolver{
+		client: client,
+	}
+}

--- a/v1/internal/component/tailscale/secrets_test.go
+++ b/v1/internal/component/tailscale/secrets_test.go
@@ -1,0 +1,486 @@
+package tailscale
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+// mockOpenBAOClient is a mock implementation of OpenBAOClient for testing.
+type mockOpenBAOClient struct {
+	secrets map[string]*Secret
+	readErr error
+}
+
+func (m *mockOpenBAOClient) Read(ctx context.Context, path string) (*Secret, error) {
+	if m.readErr != nil {
+		return nil, m.readErr
+	}
+	secret, ok := m.secrets[path]
+	if !ok {
+		return nil, fmt.Errorf("secret not found at path %q", path)
+	}
+	return secret, nil
+}
+
+func TestNewSecretResolver(t *testing.T) {
+	client := &mockOpenBAOClient{}
+	resolver := NewSecretResolver(client)
+	if resolver == nil {
+		t.Fatal("NewSecretResolver() returned nil")
+	}
+	if resolver.client != client {
+		t.Error("NewSecretResolver() did not set client")
+	}
+}
+
+func TestIsSecretReference(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{
+			name:  "valid secret reference",
+			value: "${secret:path/to/secret:key}",
+			want:  true,
+		},
+		{
+			name:  "valid secret reference with colon in path",
+			value: "${secret:foundry-core/tailscale:client_id}",
+			want:  true,
+		},
+		{
+			name:  "literal value",
+			value: "literal-client-id",
+			want:  false,
+		},
+		{
+			name:  "missing closing brace",
+			value: "${secret:path:key",
+			want:  false,
+		},
+		{
+			name:  "wrong prefix",
+			value: "${config:path:key}",
+			want:  false,
+		},
+		{
+			name:  "empty string",
+			value: "",
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isSecretReference(tt.value)
+			if got != tt.want {
+				t.Errorf("isSecretReference(%q) = %v, want %v", tt.value, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseSecretReference(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		wantPath string
+		wantKey  string
+		wantErr  bool
+	}{
+		{
+			name:     "simple reference",
+			value:    "${secret:path/to/secret:key}",
+			wantPath: "path/to/secret",
+			wantKey:  "key",
+			wantErr:  false,
+		},
+		{
+			name:     "reference with colon in path",
+			value:    "${secret:foundry-core/tailscale:client_id}",
+			wantPath: "foundry-core/tailscale",
+			wantKey:  "client_id",
+			wantErr:  false,
+		},
+		{
+			name:     "reference with multiple colons",
+			value:    "${secret:a:b:c:key}",
+			wantPath: "a:b:c",
+			wantKey:  "key",
+			wantErr:  false,
+		},
+		{
+			name:    "missing key",
+			value:   "${secret:path}",
+			wantErr: true,
+		},
+		{
+			name:    "not a reference",
+			value:   "literal-value",
+			wantErr: true,
+		},
+		{
+			name:    "empty path",
+			value:   "${secret::key}",
+			wantErr: true,
+		},
+		{
+			name:    "empty key",
+			value:   "${secret:path:}",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path, key, err := parseSecretReference(tt.value)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseSecretReference(%q) error = %v, wantErr %v", tt.value, err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr {
+				if path != tt.wantPath {
+					t.Errorf("parseSecretReference(%q) path = %q, want %q", tt.value, path, tt.wantPath)
+				}
+				if key != tt.wantKey {
+					t.Errorf("parseSecretReference(%q) key = %q, want %q", tt.value, key, tt.wantKey)
+				}
+			}
+		})
+	}
+}
+
+func TestSecretResolver_Resolve_LiteralValues(t *testing.T) {
+	client := &mockOpenBAOClient{}
+	resolver := NewSecretResolver(client)
+
+	tests := []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{
+			name:  "simple literal",
+			value: "literal-client-id",
+			want:  "literal-client-id",
+		},
+		{
+			name:  "UUID literal",
+			value: "550e8400-e29b-41d4-a716-446655440000",
+			want:  "550e8400-e29b-41d4-a716-446655440000",
+		},
+		{
+			name:  "empty string",
+			value: "",
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolver.Resolve(context.Background(), tt.value)
+			if err != nil {
+				t.Errorf("Resolve() unexpected error: %v", err)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("Resolve(%q) = %q, want %q", tt.value, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSecretResolver_Resolve_SecretReferences(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		secrets map[string]*Secret
+		want    string
+		wantErr bool
+		errContains string
+	}{
+		{
+			name:  "successful resolution",
+			value: "${secret:foundry-core/tailscale:client_id}",
+			secrets: map[string]*Secret{
+				"foundry-core/tailscale": {
+					Data: map[string]interface{}{
+						"client_id":     "my-client-id",
+						"client_secret": "my-client-secret",
+					},
+				},
+			},
+			want:    "my-client-id",
+			wantErr: false,
+		},
+		{
+			name:  "secret not found",
+			value: "${secret:nonexistent/path:key}",
+			secrets: map[string]*Secret{},
+			wantErr: true,
+			errContains: "failed to read secret from OpenBAO",
+		},
+		{
+			name:  "key not found in secret",
+			value: "${secret:foundry-core/tailscale:nonexistent_key}",
+			secrets: map[string]*Secret{
+				"foundry-core/tailscale": {
+					Data: map[string]interface{}{
+						"client_id": "my-client-id",
+					},
+				},
+			},
+			wantErr: true,
+			errContains: "key \"nonexistent_key\" not found",
+		},
+		{
+			name:  "value is not a string",
+			value: "${secret:foundry-core/tailscale:numeric_value}",
+			secrets: map[string]*Secret{
+				"foundry-core/tailscale": {
+					Data: map[string]interface{}{
+						"numeric_value": 12345,
+					},
+				},
+			},
+			wantErr: true,
+			errContains: "is not a string",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &mockOpenBAOClient{
+				secrets: tt.secrets,
+			}
+			resolver := NewSecretResolver(client)
+
+			got, err := resolver.Resolve(context.Background(), tt.value)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Resolve() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if err != nil && tt.errContains != "" && !contains(err.Error(), tt.errContains) {
+				t.Errorf("Resolve() error = %q, want to contain %q", err.Error(), tt.errContains)
+				return
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("Resolve() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSecretResolver_Resolve_NilClient(t *testing.T) {
+	resolver := NewSecretResolver(nil)
+
+	tests := []struct {
+		name    string
+		value   string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "literal value with nil client",
+			value:   "literal-value",
+			want:    "literal-value",
+			wantErr: false,
+		},
+		{
+			name:    "secret reference with nil client",
+			value:   "${secret:path:key}",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolver.Resolve(context.Background(), tt.value)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Resolve() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("Resolve() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSecretResolver_Resolve_OpenBAOError(t *testing.T) {
+	client := &mockOpenBAOClient{
+		readErr: fmt.Errorf("connection timeout"),
+	}
+	resolver := NewSecretResolver(client)
+
+	_, err := resolver.Resolve(context.Background(), "${secret:path:key}")
+	if err == nil {
+		t.Fatal("Resolve() expected error, got nil")
+	}
+	if !contains(err.Error(), "failed to read secret from OpenBAO") {
+		t.Errorf("Resolve() error = %q, want to contain %q", err.Error(), "failed to read secret from OpenBAO")
+	}
+}
+
+func TestSecretResolver_ResolveConfig(t *testing.T) {
+	tests := []struct {
+		name              string
+		config            *Config
+		secrets           map[string]*Secret
+		wantClientID      string
+		wantClientSecret  string
+		wantErr           bool
+		errContains       string
+	}{
+		{
+			name: "resolve both OAuth fields",
+			config: &Config{
+				OAuthClientID:     stringPtr("${secret:foundry-core/tailscale:client_id}"),
+				OAuthClientSecret: stringPtr("${secret:foundry-core/tailscale:client_secret}"),
+			},
+			secrets: map[string]*Secret{
+				"foundry-core/tailscale": {
+					Data: map[string]interface{}{
+						"client_id":     "resolved-client-id",
+						"client_secret": "resolved-client-secret",
+					},
+				},
+			},
+			wantClientID:     "resolved-client-id",
+			wantClientSecret: "resolved-client-secret",
+			wantErr:          false,
+		},
+		{
+			name: "literal values unchanged",
+			config: &Config{
+				OAuthClientID:     stringPtr("literal-client-id"),
+				OAuthClientSecret: stringPtr("literal-client-secret"),
+			},
+			secrets:          map[string]*Secret{},
+			wantClientID:     "literal-client-id",
+			wantClientSecret: "literal-client-secret",
+			wantErr:          false,
+		},
+		{
+			name: "mixed literal and secret",
+			config: &Config{
+				OAuthClientID:     stringPtr("literal-client-id"),
+				OAuthClientSecret: stringPtr("${secret:foundry-core/tailscale:client_secret}"),
+			},
+			secrets: map[string]*Secret{
+				"foundry-core/tailscale": {
+					Data: map[string]interface{}{
+						"client_secret": "resolved-client-secret",
+					},
+				},
+			},
+			wantClientID:     "literal-client-id",
+			wantClientSecret: "resolved-client-secret",
+			wantErr:          false,
+		},
+		{
+			name: "client_id resolution error",
+			config: &Config{
+				OAuthClientID:     stringPtr("${secret:nonexistent/path:key}"),
+				OAuthClientSecret: stringPtr("literal-secret"),
+			},
+			secrets:     map[string]*Secret{},
+			wantErr:     true,
+			errContains: "failed to resolve oauth_client_id",
+		},
+		{
+			name: "client_secret resolution error",
+			config: &Config{
+				OAuthClientID:     stringPtr("literal-id"),
+				OAuthClientSecret: stringPtr("${secret:nonexistent/path:key}"),
+			},
+			secrets:     map[string]*Secret{},
+			wantErr:     true,
+			errContains: "failed to resolve oauth_client_secret",
+		},
+		{
+			name:    "nil config",
+			config:  nil,
+			secrets: map[string]*Secret{},
+			wantErr: true,
+			errContains: "config cannot be nil",
+		},
+		{
+			name: "empty strings not resolved",
+			config: &Config{
+				OAuthClientID:     stringPtr(""),
+				OAuthClientSecret: stringPtr(""),
+			},
+			secrets:          map[string]*Secret{},
+			wantClientID:     "",
+			wantClientSecret: "",
+			wantErr:          false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &mockOpenBAOClient{
+				secrets: tt.secrets,
+			}
+			resolver := NewSecretResolver(client)
+
+			err := resolver.ResolveConfig(context.Background(), tt.config)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ResolveConfig() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if err != nil && tt.errContains != "" && !contains(err.Error(), tt.errContains) {
+				t.Errorf("ResolveConfig() error = %q, want to contain %q", err.Error(), tt.errContains)
+				return
+			}
+
+			if !tt.wantErr && tt.config != nil {
+				if tt.config.OAuthClientID != nil && *tt.config.OAuthClientID != tt.wantClientID {
+					t.Errorf("OAuthClientID = %q, want %q", *tt.config.OAuthClientID, tt.wantClientID)
+				}
+				if tt.config.OAuthClientSecret != nil && *tt.config.OAuthClientSecret != tt.wantClientSecret {
+					t.Errorf("OAuthClientSecret = %q, want %q", *tt.config.OAuthClientSecret, tt.wantClientSecret)
+				}
+			}
+		})
+	}
+}
+
+func TestNewSecretResolverWithFallback(t *testing.T) {
+	// Test with nil client
+	resolver := NewSecretResolverWithFallback(nil)
+	if resolver == nil {
+		t.Fatal("NewSecretResolverWithFallback() returned nil")
+	}
+
+	// Should handle literal values even with nil client
+	val, err := resolver.Resolve(context.Background(), "literal-value")
+	if err != nil {
+		t.Errorf("Resolve() with literal value unexpected error: %v", err)
+	}
+	if val != "literal-value" {
+		t.Errorf("Resolve() = %q, want %q", val, "literal-value")
+	}
+
+	// Test with real client
+	client := &mockOpenBAOClient{
+		secrets: map[string]*Secret{
+			"test": {
+				Data: map[string]interface{}{
+					"key": "value",
+				},
+			},
+		},
+	}
+	resolver = NewSecretResolverWithFallback(client)
+	val, err = resolver.Resolve(context.Background(), "${secret:test:key}")
+	if err != nil {
+		t.Errorf("Resolve() with secret reference unexpected error: %v", err)
+	}
+	if val != "value" {
+		t.Errorf("Resolve() = %q, want %q", val, "value")
+	}
+}

--- a/v1/internal/component/tailscale/types.go
+++ b/v1/internal/component/tailscale/types.go
@@ -1,0 +1,47 @@
+package tailscale
+
+import (
+	"fmt"
+)
+
+// Validate checks that the Tailscale configuration is valid.
+// It ensures required OAuth credentials are provided.
+func (c *Config) Validate() error {
+	if c == nil {
+		return fmt.Errorf("config cannot be nil")
+	}
+
+	// OAuth credentials are required
+	if c.OAuthClientID == nil || *c.OAuthClientID == "" {
+		return fmt.Errorf("oauth_client_id is required")
+	}
+	if c.OAuthClientSecret == nil || *c.OAuthClientSecret == "" {
+		return fmt.Errorf("oauth_client_secret is required")
+	}
+
+	return nil
+}
+
+// SetDefaults sets default values for optional fields if not provided.
+func (c *Config) SetDefaults() {
+	if c == nil {
+		return
+	}
+
+	// Set default operator image if not specified
+	if c.OperatorImage == nil {
+		image := "tailscale/operator:latest"
+		c.OperatorImage = &image
+	}
+
+	// Set default tags if not specified
+	if c.Tags == nil {
+		c.Tags = []string{"tag:k8s-foundry"}
+	}
+
+	// Initialize advertise_routes as empty slice if nil
+	// (will be populated with VIP route during installation)
+	if c.AdvertiseRoutes == nil {
+		c.AdvertiseRoutes = []string{}
+	}
+}

--- a/v1/internal/component/tailscale/types.go
+++ b/v1/internal/component/tailscale/types.go
@@ -4,6 +4,35 @@ import (
 	"fmt"
 )
 
+// Config holds Tailscale operator component configuration
+type Config struct {
+	// OAuthClientID is the OAuth client ID for Tailscale
+	OAuthClientID *string `json:"oauth_client_id" yaml:"oauth_client_id"`
+
+	// OAuthClientSecret is the OAuth client secret for Tailscale
+	OAuthClientSecret *string `json:"oauth_client_secret" yaml:"oauth_client_secret"`
+
+	// OperatorImage is the image for the Tailscale operator
+	OperatorImage *string `json:"operator_image" yaml:"operator_image"`
+
+	// Tags are the Tailscale tags to apply to the node
+	Tags []string `json:"tags" yaml:"tags"`
+
+	// AdvertiseRoutes are the routes to advertise to Tailscale
+	AdvertiseRoutes []string `json:"advertise_routes" yaml:"advertise_routes"`
+
+	// Version is the Helm chart version to install
+	Version string `json:"version" yaml:"version"`
+
+	// Namespace for Tailscale operator deployment
+	Namespace string `json:"namespace" yaml:"namespace"`
+
+	// CustomDomain is a custom DNS domain to use instead of the default ts.net
+	// For example: "soypetetech.local" will make ingresses available at
+	// grafana.soypetetech.local instead of grafana.<random>.ts.net
+	CustomDomain string `json:"custom_domain" yaml:"custom_domain"`
+}
+
 // Validate checks that the Tailscale configuration is valid.
 // It ensures required OAuth credentials are provided.
 func (c *Config) Validate() error {
@@ -43,5 +72,10 @@ func (c *Config) SetDefaults() {
 	// (will be populated with VIP route during installation)
 	if c.AdvertiseRoutes == nil {
 		c.AdvertiseRoutes = []string{}
+	}
+
+	// CustomDomain defaults to empty (uses default ts.net domain)
+	if c.CustomDomain == "" {
+		c.CustomDomain = ""
 	}
 }

--- a/v1/internal/component/tailscale/types_validation_test.go
+++ b/v1/internal/component/tailscale/types_validation_test.go
@@ -1,0 +1,207 @@
+package tailscale
+
+import (
+	"testing"
+)
+
+func TestConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  *Config
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "nil config",
+			config:  nil,
+			wantErr: true,
+			errMsg:  "config cannot be nil",
+		},
+		{
+			name: "missing oauth_client_id",
+			config: &Config{
+				OAuthClientSecret: stringPtr("secret-456"),
+			},
+			wantErr: true,
+			errMsg:  "oauth_client_id is required",
+		},
+		{
+			name: "empty oauth_client_id",
+			config: &Config{
+				OAuthClientID:     stringPtr(""),
+				OAuthClientSecret: stringPtr("secret-456"),
+			},
+			wantErr: true,
+			errMsg:  "oauth_client_id is required",
+		},
+		{
+			name: "missing oauth_client_secret",
+			config: &Config{
+				OAuthClientID: stringPtr("client-123"),
+			},
+			wantErr: true,
+			errMsg:  "oauth_client_secret is required",
+		},
+		{
+			name: "empty oauth_client_secret",
+			config: &Config{
+				OAuthClientID:     stringPtr("client-123"),
+				OAuthClientSecret: stringPtr(""),
+			},
+			wantErr: true,
+			errMsg:  "oauth_client_secret is required",
+		},
+		{
+			name: "valid minimal config",
+			config: &Config{
+				OAuthClientID:     stringPtr("client-123"),
+				OAuthClientSecret: stringPtr("secret-456"),
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid full config",
+			config: &Config{
+				OAuthClientID:     stringPtr("client-123"),
+				OAuthClientSecret: stringPtr("secret-456"),
+				OperatorImage:     stringPtr("tailscale/operator:v1.2.3"),
+				AdvertiseRoutes:   []string{"10.0.0.0/8"},
+				Tags:              []string{"tag:k8s-foundry", "tag:production"},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if err != nil && tt.errMsg != "" && err.Error() != tt.errMsg {
+				t.Errorf("Validate() error message = %q, want %q", err.Error(), tt.errMsg)
+			}
+		})
+	}
+}
+
+func TestConfig_SetDefaults(t *testing.T) {
+	tests := []struct {
+		name   string
+		config *Config
+		check  func(t *testing.T, cfg *Config)
+	}{
+		{
+			name:   "nil config does not panic",
+			config: nil,
+			check: func(t *testing.T, cfg *Config) {
+				// Should not panic
+			},
+		},
+		{
+			name: "sets default operator image",
+			config: &Config{
+				OAuthClientID:     stringPtr("client-123"),
+				OAuthClientSecret: stringPtr("secret-456"),
+			},
+			check: func(t *testing.T, cfg *Config) {
+				if cfg.OperatorImage == nil {
+					t.Error("Expected OperatorImage to be set")
+					return
+				}
+				if *cfg.OperatorImage != "tailscale/operator:latest" {
+					t.Errorf("OperatorImage = %q, want %q", *cfg.OperatorImage, "tailscale/operator:latest")
+				}
+			},
+		},
+		{
+			name: "preserves custom operator image",
+			config: &Config{
+				OAuthClientID:     stringPtr("client-123"),
+				OAuthClientSecret: stringPtr("secret-456"),
+				OperatorImage:     stringPtr("custom/operator:v1.0.0"),
+			},
+			check: func(t *testing.T, cfg *Config) {
+				if cfg.OperatorImage == nil {
+					t.Error("Expected OperatorImage to be set")
+					return
+				}
+				if *cfg.OperatorImage != "custom/operator:v1.0.0" {
+					t.Errorf("OperatorImage = %q, want %q", *cfg.OperatorImage, "custom/operator:v1.0.0")
+				}
+			},
+		},
+		{
+			name: "sets default tags",
+			config: &Config{
+				OAuthClientID:     stringPtr("client-123"),
+				OAuthClientSecret: stringPtr("secret-456"),
+			},
+			check: func(t *testing.T, cfg *Config) {
+				if cfg.Tags == nil {
+					t.Error("Expected Tags to be set")
+					return
+				}
+				if len(cfg.Tags) != 1 || cfg.Tags[0] != "tag:k8s-foundry" {
+					t.Errorf("Tags = %v, want [tag:k8s-foundry]", cfg.Tags)
+				}
+			},
+		},
+		{
+			name: "preserves custom tags",
+			config: &Config{
+				OAuthClientID:     stringPtr("client-123"),
+				OAuthClientSecret: stringPtr("secret-456"),
+				Tags:              []string{"tag:custom", "tag:production"},
+			},
+			check: func(t *testing.T, cfg *Config) {
+				if len(cfg.Tags) != 2 {
+					t.Errorf("Tags length = %d, want 2", len(cfg.Tags))
+				}
+			},
+		},
+		{
+			name: "initializes empty advertise routes",
+			config: &Config{
+				OAuthClientID:     stringPtr("client-123"),
+				OAuthClientSecret: stringPtr("secret-456"),
+			},
+			check: func(t *testing.T, cfg *Config) {
+				if cfg.AdvertiseRoutes == nil {
+					t.Error("Expected AdvertiseRoutes to be initialized")
+					return
+				}
+				if len(cfg.AdvertiseRoutes) != 0 {
+					t.Errorf("AdvertiseRoutes length = %d, want 0", len(cfg.AdvertiseRoutes))
+				}
+			},
+		},
+		{
+			name: "preserves custom advertise routes",
+			config: &Config{
+				OAuthClientID:     stringPtr("client-123"),
+				OAuthClientSecret: stringPtr("secret-456"),
+				AdvertiseRoutes:   []string{"10.0.0.0/8", "192.168.0.0/16"},
+			},
+			check: func(t *testing.T, cfg *Config) {
+				if len(cfg.AdvertiseRoutes) != 2 {
+					t.Errorf("AdvertiseRoutes length = %d, want 2", len(cfg.AdvertiseRoutes))
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := tt.config
+			cfg.SetDefaults()
+			tt.check(t, cfg)
+		})
+	}
+}
+
+// Helper function to create string pointers
+func stringPtr(s string) *string {
+	return &s
+}

--- a/v1/internal/config/types.gen.go
+++ b/v1/internal/config/types.gen.go
@@ -4,46 +4,46 @@
 package config
 
 import (
-	"github.com/catalystcommunity/foundry/v1/internal/setup"
 	"github.com/catalystcommunity/foundry/v1/internal/host"
+	"github.com/catalystcommunity/foundry/v1/internal/setup"
 )
 
 // NetworkConfig represents a structured data type
 type NetworkConfig struct {
-	Gateway string `json:"gateway" yaml:"gateway"`
-	Netmask string `json:"netmask" yaml:"netmask"`
+	Gateway   string     `json:"gateway" yaml:"gateway"`
+	Netmask   string     `json:"netmask" yaml:"netmask"`
 	DHCPRange *DHCPRange `json:"dhcp_range,omitempty" yaml:"dhcp_range,omitempty"`
 }
 
 // DHCPRange represents a structured data type
 type DHCPRange struct {
 	Start string `json:"start" yaml:"start"`
-	End string `json:"end" yaml:"end"`
+	End   string `json:"end" yaml:"end"`
 }
 
 // DNSConfig represents a structured data type
 type DNSConfig struct {
 	InfrastructureZones []DNSZone `json:"infrastructure_zones" yaml:"infrastructure_zones"`
-	KubernetesZones []DNSZone `json:"kubernetes_zones" yaml:"kubernetes_zones"`
-	Forwarders []string `json:"forwarders" yaml:"forwarders"`
-	Backend string `json:"backend" yaml:"backend"`
-	APIKey string `json:"api_key" yaml:"api_key"`
+	KubernetesZones     []DNSZone `json:"kubernetes_zones" yaml:"kubernetes_zones"`
+	Forwarders          []string  `json:"forwarders" yaml:"forwarders"`
+	Backend             string    `json:"backend" yaml:"backend"`
+	APIKey              string    `json:"api_key" yaml:"api_key"`
 }
 
 // DNSZone represents a structured data type
 type DNSZone struct {
-	Name string `json:"name" yaml:"name"`
-	Public bool `json:"public" yaml:"public"`
+	Name        string  `json:"name" yaml:"name"`
+	Public      bool    `json:"public" yaml:"public"`
 	PublicCNAME *string `json:"public_cname,omitempty" yaml:"public_cname,omitempty"`
 }
 
 // ClusterConfig represents a structured data type
 type ClusterConfig struct {
-	Name string `json:"name" yaml:"name"`
-	Domain *string `json:"domain,omitempty" yaml:"domain,omitempty"`
-	PrimaryDomain string `json:"primary_domain" yaml:"primary_domain"`
-	VIP string `json:"vip" yaml:"vip"`
-	AllowCGNATVIP *bool `json:"allow_cgnat_vip,omitempty" yaml:"allow_cgnat_vip,omitempty"`
+	Name          string  `json:"name" yaml:"name"`
+	Domain        *string `json:"domain,omitempty" yaml:"domain,omitempty"`
+	PrimaryDomain string  `json:"primary_domain" yaml:"primary_domain"`
+	VIP           string  `json:"vip" yaml:"vip"`
+	AllowCGNATVIP *bool   `json:"allow_cgnat_vip,omitempty" yaml:"allow_cgnat_vip,omitempty"`
 }
 
 // ComponentMap is a type alias
@@ -51,16 +51,16 @@ type ComponentMap map[string]ComponentConfig
 
 // ComponentConfig represents a structured data type
 type ComponentConfig struct {
-	Version *string `json:"version,omitempty" yaml:"version,omitempty"`
-	Hosts []string `json:"hosts,omitempty" yaml:"hosts,omitempty"`
-	Config map[string]any `json:"config" yaml:",inline"`
+	Version *string        `json:"version,omitempty" yaml:"version,omitempty"`
+	Hosts   []string       `json:"hosts,omitempty" yaml:"hosts,omitempty"`
+	Config  map[string]any `json:"config" yaml:",inline"`
 }
 
 // ObsConfig represents a structured data type
 type ObsConfig struct {
 	Prometheus *PrometheusConfig `json:"prometheus,omitempty" yaml:"prometheus,omitempty"`
-	Loki *LokiConfig `json:"loki,omitempty" yaml:"loki,omitempty"`
-	Grafana *GrafanaConfig `json:"grafana,omitempty" yaml:"grafana,omitempty"`
+	Loki       *LokiConfig       `json:"loki,omitempty" yaml:"loki,omitempty"`
+	Grafana    *GrafanaConfig    `json:"grafana,omitempty" yaml:"grafana,omitempty"`
 }
 
 // PrometheusConfig represents a structured data type
@@ -80,7 +80,7 @@ type GrafanaConfig struct {
 
 // StorageConfig represents a structured data type
 type StorageConfig struct {
-	Backend string `json:"backend" yaml:"backend"`
+	Backend string         `json:"backend" yaml:"backend"`
 	TrueNAS *TrueNASConfig `json:"truenas,omitempty" yaml:"truenas,omitempty"`
 }
 
@@ -92,13 +92,12 @@ type TrueNASConfig struct {
 
 // Config represents a structured data type
 type Config struct {
-	Network *NetworkConfig `json:"network,omitempty" yaml:"network,omitempty"`
-	DNS *DNSConfig `json:"dns,omitempty" yaml:"dns,omitempty"`
-	Cluster ClusterConfig `json:"cluster" yaml:"cluster"`
-	Components ComponentMap `json:"components" yaml:"components"`
-	Observability *ObsConfig `json:"observability,omitempty" yaml:"observability,omitempty"`
-	Storage *StorageConfig `json:"storage,omitempty" yaml:"storage,omitempty"`
-	Hosts []*host.Host `json:"hosts" yaml:"hosts"`
-	SetupState *setup.SetupState `json:"setup_state" yaml:"setup_state"`
+	Network       *NetworkConfig    `json:"network,omitempty" yaml:"network,omitempty"`
+	DNS           *DNSConfig        `json:"dns,omitempty" yaml:"dns,omitempty"`
+	Cluster       ClusterConfig     `json:"cluster" yaml:"cluster"`
+	Components    ComponentMap      `json:"components" yaml:"components"`
+	Observability *ObsConfig        `json:"observability,omitempty" yaml:"observability,omitempty"`
+	Storage       *StorageConfig    `json:"storage,omitempty" yaml:"storage,omitempty"`
+	Hosts         []*host.Host      `json:"hosts" yaml:"hosts"`
+	SetupState    *setup.SetupState `json:"setup_state" yaml:"setup_state"`
 }
-


### PR DESCRIPTION
## Summary
- Add CustomDomain configuration option to Tailscale component types
- Update install.go for proper namespace detection (grafana/loki in monitoring)
- Add isPrometheusCRInstalled check for kube-prometheus-stack operator

## Context
User wants custom domain support (soypetetech.local) instead of default ts.net for Tailscale ingresses. This adds the config field as a placeholder for future implementation.