### PR TITLE
feat: add gatewayapi support for tcp/tls and a controller helper

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,20 @@
+# Keep the build context small: only v1/ source is needed by the Dockerfile.
+.git
+.github
+docs
+deploy
+.claude
+*.md
+LICENSE
+
+# Build artifacts and local files
+foundry
+v1/foundry
+**/coverage.out
+**/coverage.html
+*.test
+bin/
+dist/
+build/
+.vscode/
+.idea/

--- a/.reactorcide/jobs/conventional-commits.yaml
+++ b/.reactorcide/jobs/conventional-commits.yaml
@@ -1,0 +1,49 @@
+name: foundry-conventional-commits
+description: "Validate PR commits follow conventional commits (semver-tags drives releases from these)"
+triggers:
+  events:
+    - pull_request_opened
+    - pull_request_updated
+  branches:
+    - main
+job:
+  image: containers.catalystsquad.com/public/reactorcide/runnerbase:dev
+  command: |
+    set -e
+    # SOURCE_URL/HEAD_URL point at the fork for cross-repo PRs; BASE_URL is the
+    # upstream, added as a second remote so `git log base..HEAD` works.
+    git clone --branch "${REACTORCIDE_HEAD_REF:-$REACTORCIDE_PR_REF}" \
+      "${REACTORCIDE_HEAD_URL:-$REACTORCIDE_SOURCE_URL}" /job/src
+    cd /job/src
+    if [ -n "${REACTORCIDE_BASE_URL}" ] && \
+       [ "${REACTORCIDE_BASE_URL}" != "${REACTORCIDE_HEAD_URL:-$REACTORCIDE_SOURCE_URL}" ]; then
+      git remote add upstream "${REACTORCIDE_BASE_URL}"
+      git fetch upstream "${REACTORCIDE_BASE_REF:-$REACTORCIDE_PR_BASE_REF}"
+    fi
+
+    echo "=== Validating Conventional Commits ==="
+    PATTERN='^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert|norelease)(\(.+\))?!?: .+'
+    FAILED=0
+    git log "${REACTORCIDE_DIFF_BASE}..HEAD" --pretty=format:"%H %s" > /tmp/commits.txt
+    while IFS= read -r LINE; do
+      HASH=$(echo "${LINE}" | cut -d' ' -f1)
+      MSG=$(echo "${LINE}" | cut -d' ' -f2-)
+      if echo "${MSG}" | grep -qE "${PATTERN}"; then
+        echo "OK: ${MSG}"
+      else
+        echo "FAIL: ${MSG} (${HASH})"
+        FAILED=1
+      fi
+    done < /tmp/commits.txt
+
+    if [ "${FAILED}" = "1" ]; then
+      echo ""
+      echo "Commit messages must match: type(scope)?: description"
+      echo "Valid types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert, norelease"
+      exit 1
+    fi
+    echo "All commits follow conventional commit format."
+  timeout: 300
+  priority: 10
+  raw_command: true
+  disable_run_local: true

--- a/.reactorcide/jobs/helm-validate.yaml
+++ b/.reactorcide/jobs/helm-validate.yaml
@@ -1,0 +1,29 @@
+name: foundry-helm-validate
+description: "Lint and template the gateway-controller helm chart on PRs that touch it"
+triggers:
+  events:
+    - pull_request_opened
+    - pull_request_updated
+  branches:
+    - main
+paths:
+  include:
+    - "deploy/charts/**"
+job:
+  image: alpine/helm:3.14.0
+  command: |
+    set -e
+    if [ "${REACTORCIDE_WORKER_MODE:-remote}" = "local" ]; then
+      cd /job/src
+    else
+      git clone --branch "${REACTORCIDE_HEAD_REF:-$REACTORCIDE_PR_REF}" \
+        "${REACTORCIDE_HEAD_URL:-$REACTORCIDE_SOURCE_URL}" /job/src
+      cd /job/src
+    fi
+    CHART=./deploy/charts/foundry-gateway-controller
+    helm lint "${CHART}"
+    helm template "${CHART}" >/dev/null
+    echo "helm chart OK"
+  timeout: 600
+  priority: 10
+  raw_command: true

--- a/.reactorcide/jobs/image-build-test.yaml
+++ b/.reactorcide/jobs/image-build-test.yaml
@@ -1,0 +1,20 @@
+name: foundry-image-build-test
+description: "Verify the foundry container image builds on PRs that touch the build (no push)"
+triggers:
+  events:
+    - pull_request_opened
+    - pull_request_updated
+  branches:
+    - main
+paths:
+  include:
+    - "v1/**"
+    - "Dockerfile"
+    - ".dockerignore"
+job:
+  image: containers.catalystsquad.com/public/reactorcide/runnerbase:dev
+  command: "bash /job/src/.reactorcide/jobs/scripts/image-build-test.sh"
+  timeout: 1800
+  priority: 10
+  capabilities:
+    - builder

--- a/.reactorcide/jobs/release-helm.yaml
+++ b/.reactorcide/jobs/release-helm.yaml
@@ -1,0 +1,30 @@
+name: foundry-release-helm
+description: "On merge to main touching the chart: package it and publish a GitHub release"
+triggers:
+  events:
+    - pull_request_merged
+  branches:
+    - main
+paths:
+  include:
+    - "deploy/charts/foundry-gateway-controller/**"
+job:
+  image: containers.catalystsquad.com/public/reactorcide/runnerbase:dev
+  # Clone the repo ourselves (triggered child jobs don't get /job/src populated) —
+  # the linkkeys release pattern. The authed clone gives semver-tags full history,
+  # tags, and a push-capable origin. The script operates on the current dir.
+  command: |
+    set -e
+    if [ "${REACTORCIDE_WORKER_MODE:-remote}" = "local" ]; then
+      cd /job/src
+    else
+      git clone "https://x-access-token:${GITHUB_PAT}@github.com/${REACTORCIDE_REPO}.git" /workspace
+      cd /workspace
+    fi
+    bash .reactorcide/jobs/scripts/release-helm.sh
+  timeout: 1200
+  priority: 15
+  raw_command: true
+  disable_run_local: true
+environment:
+  GITHUB_PAT: "${secret:catalystcommunity/ci:githubpat}"

--- a/.reactorcide/jobs/release-server.yaml
+++ b/.reactorcide/jobs/release-server.yaml
@@ -1,0 +1,38 @@
+name: foundry-release-server
+description: "On merge to main: semver-tag, build + push the foundry image, bump chart appVersion"
+triggers:
+  events:
+    - pull_request_merged
+  branches:
+    - main
+paths:
+  include:
+    - "v1/**"
+    - "csil/**"
+    - "Dockerfile"
+job:
+  image: containers.catalystsquad.com/public/reactorcide/runnerbase:dev
+  # Clone the repo ourselves (triggered child jobs don't get /job/src populated) —
+  # the linkkeys release pattern. The authed clone gives semver-tags full history,
+  # tags, and a push-capable origin. The script operates on the current dir.
+  command: |
+    set -e
+    if [ "${REACTORCIDE_WORKER_MODE:-remote}" = "local" ]; then
+      cd /job/src
+    else
+      git clone "https://x-access-token:${GITHUB_PAT}@github.com/${REACTORCIDE_REPO}.git" /workspace
+      cd /workspace
+    fi
+    bash .reactorcide/jobs/scripts/release-server.sh
+  timeout: 1800
+  priority: 15
+  capabilities:
+    - docker          # build + push the image
+  raw_command: true
+  disable_run_local: true
+environment:
+  REGISTRY: "containers.catalystsquad.com"
+  IMAGE_PATH: "public/catalystcommunity/foundry"
+  REGISTRY_USER: "${secret:catalystcommunity/registry:user}"
+  REGISTRY_PASSWORD: "${secret:catalystcommunity/registry:password}"
+  GITHUB_PAT: "${secret:catalystcommunity/ci:githubpat}"

--- a/.reactorcide/jobs/scripts/image-build-test.sh
+++ b/.reactorcide/jobs/scripts/image-build-test.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+#
+# Verify the foundry image builds from the root Dockerfile (context = repo root,
+# which copies v1/). No push — this is a PR gate. Follows the linkkeys
+# server-build-test pattern: the 'builder' capability provides a buildkit sidecar
+# that buildctl talks to.
+set -euo pipefail
+
+echo "================================================"
+echo "Foundry image build test"
+echo "================================================"
+
+cd "${REACTORCIDE_REPOROOT:-/job/src}"
+
+export HOME="${HOME:-/root}"
+LOCAL_BIN="${HOME}/.local/bin"
+mkdir -p "${LOCAL_BIN}"
+export PATH="${LOCAL_BIN}:${PATH}"
+
+if ! command -v buildctl &>/dev/null; then
+    echo "Installing buildctl..."
+    BUILDKIT_VERSION=0.17.3
+    curl -fsSL "https://github.com/moby/buildkit/releases/download/v${BUILDKIT_VERSION}/buildkit-v${BUILDKIT_VERSION}.linux-amd64.tar.gz" -o /tmp/buildkit.tar.gz
+    tar -xzf /tmp/buildkit.tar.gz -C "${LOCAL_BIN}" --strip-components=1 bin/buildctl
+    rm /tmp/buildkit.tar.gz
+fi
+
+echo "Waiting for builder sidecar..."
+for i in $(seq 1 30); do
+    if buildctl debug info >/dev/null 2>&1; then
+        echo "builder sidecar is ready"
+        break
+    fi
+    if [[ $i -eq 30 ]]; then
+        echo "ERROR: builder sidecar not ready after 30 seconds"
+        exit 1
+    fi
+    sleep 1
+done
+
+echo "Building image (test only, no push)..."
+buildctl build \
+    --frontend dockerfile.v0 \
+    --local context=. \
+    --local dockerfile=. \
+    --output "type=image,name=foundry:build"
+
+echo ""
+echo "================================================"
+echo "Image build test passed!"
+echo "================================================"

--- a/.reactorcide/jobs/scripts/release-helm.sh
+++ b/.reactorcide/jobs/scripts/release-helm.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+#
+# Helm chart release. semver-tags analyzes commits under the chart dir (scoped
+# with --directories), creates + pushes a prefixed tag, then bumps Chart.yaml
+# `version`, packages, and publishes a GitHub release with the .tgz. Independent
+# of release-server (separate prefixed tag sequence).
+#
+# runnerbase ships only curl/git/bash, so semver-tags, helm, and gh are
+# curl-installed (the corndogs release-helm pattern). Runs in the dir the job
+# command cloned (an authed full clone of main).
+set -euo pipefail
+
+CHART_DIR="deploy/charts/foundry-gateway-controller"
+SEMVER_TAGS_VERSION="${SEMVER_TAGS_VERSION:-v0.4.0}"
+GHCLI_VERSION="${GHCLI_VERSION:-2.63.2}"
+
+export HOME="${HOME:-/root}"
+LOCAL_BIN="${HOME}/.local/bin"
+mkdir -p "${LOCAL_BIN}"
+export PATH="${LOCAL_BIN}:${PATH}"
+
+git config user.name "catalystcommunityci"
+git config user.email "ci@catalystcommunity.org"
+git fetch --tags --force origin
+
+echo "=== install semver-tags ${SEMVER_TAGS_VERSION} ==="
+curl -fsSL "https://github.com/catalystcommunity/semver-tags/releases/download/${SEMVER_TAGS_VERSION}/semver-tags.tar.gz" -o /tmp/semver-tags.tar.gz
+tar -xzf /tmp/semver-tags.tar.gz -C "${LOCAL_BIN}"
+chmod +x "${LOCAL_BIN}/semver-tags"
+
+echo "=== compute version bump for ${CHART_DIR}/ ==="
+semver-tags run --output_json --directories "${CHART_DIR}" > /tmp/semver.txt 2>&1
+OUTPUT=$(tail -1 /tmp/semver.txt)
+NEW_TAG=$(echo "${OUTPUT}"   | grep -o '"New_release_git_tag":"[^"]*"'  | cut -d'"' -f4)
+PUBLISHED=$(echo "${OUTPUT}" | grep -o '"New_release_published":"[^"]*"' | cut -d'"' -f4)
+
+if [ "${PUBLISHED}" != "true" ]; then
+  echo "No new chart release needed."
+  exit 0
+fi
+# tag is "<chart-dir>/vX.Y.Z" -> VERSION "X.Y.Z"
+VERSION="${NEW_TAG##*/}"
+VERSION="${VERSION#v}"
+echo "=== releasing ${NEW_TAG} (version ${VERSION}) ==="
+
+echo "=== bump chart version to ${VERSION} ==="
+sed -i "s/^version: .*/version: \"${VERSION}\"/" "${CHART_DIR}/Chart.yaml"
+git add "${CHART_DIR}/Chart.yaml"
+if ! git diff --cached --quiet; then
+  git commit -m "ci: bump chart version to ${VERSION}"
+  # release-server may also be committing Chart.yaml (a different line); rebase to
+  # serialize cleanly before pushing.
+  git pull --rebase origin main || true
+  git push origin main
+fi
+
+echo "=== install helm + package chart ==="
+if ! command -v helm >/dev/null 2>&1; then
+  curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 \
+    | USE_SUDO=false HELM_INSTALL_DIR="${LOCAL_BIN}" bash
+fi
+helm package "${CHART_DIR}"   # produces foundry-gateway-controller-${VERSION}.tgz in cwd
+
+echo "=== publish GitHub release ${NEW_TAG} ==="
+if ! command -v gh >/dev/null 2>&1; then
+  curl -fsSL "https://github.com/cli/cli/releases/download/v${GHCLI_VERSION}/gh_${GHCLI_VERSION}_linux_amd64.tar.gz" -o /tmp/gh.tar.gz
+  tar -xzf /tmp/gh.tar.gz -C /tmp
+  cp "/tmp/gh_${GHCLI_VERSION}_linux_amd64/bin/gh" "${LOCAL_BIN}/gh"
+fi
+GH_TOKEN="${GITHUB_PAT}" gh release create "${NEW_TAG}" \
+  --repo "${REACTORCIDE_REPO}" \
+  --title "${NEW_TAG}" \
+  --notes "Helm chart ${VERSION}" \
+  ./foundry-gateway-controller-*.tgz
+
+echo "=== released chart ${NEW_TAG} (version ${VERSION}) ==="

--- a/.reactorcide/jobs/scripts/release-server.sh
+++ b/.reactorcide/jobs/scripts/release-server.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+#
+# Server release. semver-tags analyzes commits under v1/ (scoped with
+# --directories) and, on a real bump, creates + pushes a prefixed tag
+# `v1/vX.Y.Z`. We then build + push the image and bump the chart appVersion.
+# Independent of release-helm (separate prefixed tag sequence).
+#
+# The runnerbase image ships only curl/git/bash, so semver-tags, the docker CLI,
+# crane, and gh are all curl-installed (the corndogs release-server pattern).
+# Runs in the dir the job command cloned (an authed full clone of main).
+set -euo pipefail
+
+SEMVER_TAGS_VERSION="${SEMVER_TAGS_VERSION:-v0.4.0}"
+GHCLI_VERSION="${GHCLI_VERSION:-2.63.2}"
+CRANE_VERSION="${CRANE_VERSION:-0.20.3}"
+DOCKER_VERSION="${DOCKER_VERSION:-27.5.1}"
+
+export HOME="${HOME:-/root}"
+LOCAL_BIN="${HOME}/.local/bin"
+mkdir -p "${LOCAL_BIN}" "${HOME}/.docker"
+export PATH="${LOCAL_BIN}:${PATH}"
+
+git config user.name "catalystcommunityci"
+git config user.email "ci@catalystcommunity.org"
+git fetch --tags --force origin
+
+echo "=== install semver-tags ${SEMVER_TAGS_VERSION} ==="
+curl -fsSL "https://github.com/catalystcommunity/semver-tags/releases/download/${SEMVER_TAGS_VERSION}/semver-tags.tar.gz" -o /tmp/semver-tags.tar.gz
+tar -xzf /tmp/semver-tags.tar.gz -C "${LOCAL_BIN}"
+chmod +x "${LOCAL_BIN}/semver-tags"
+
+echo "=== compute version bump for v1/ ==="
+semver-tags run --output_json --directories v1 > /tmp/semver.txt 2>&1
+OUTPUT=$(tail -1 /tmp/semver.txt)
+NEW_TAG=$(echo "${OUTPUT}"   | grep -o '"New_release_git_tag":"[^"]*"'  | cut -d'"' -f4)
+PUBLISHED=$(echo "${OUTPUT}" | grep -o '"New_release_published":"[^"]*"' | cut -d'"' -f4)
+
+if [ "${PUBLISHED}" != "true" ]; then
+  echo "No new server release needed."
+  exit 0
+fi
+# tag is "v1/vX.Y.Z" -> VERSION "X.Y.Z"
+VERSION="${NEW_TAG##*/}"
+VERSION="${VERSION#v}"
+echo "=== releasing ${NEW_TAG} (version ${VERSION}) ==="
+
+IMAGE="${REGISTRY}/${IMAGE_PATH}"
+
+echo "=== install crane ==="
+if ! command -v crane >/dev/null 2>&1; then
+  curl -fsSL "https://github.com/google/go-containerregistry/releases/download/v${CRANE_VERSION}/go-containerregistry_Linux_x86_64.tar.gz" -o /tmp/crane.tar.gz
+  tar -xzf /tmp/crane.tar.gz -C "${LOCAL_BIN}" crane
+  rm /tmp/crane.tar.gz
+fi
+
+# Registry auth for crane (docker config.json).
+AUTH=$(printf "%s:%s" "${REGISTRY_USER}" "${REGISTRY_PASSWORD}" | base64 -w 0)
+cat > "${HOME}/.docker/config.json" <<EOF
+{ "auths": { "${REGISTRY}": {"auth": "${AUTH}"} } }
+EOF
+
+echo "=== build + push ${IMAGE}:${VERSION} ==="
+if [ -z "${DOCKER_HOST:-}" ]; then
+  echo "ERROR: DOCKER_HOST not set (this job needs the 'docker' capability)" >&2
+  exit 1
+fi
+if ! command -v docker >/dev/null 2>&1; then
+  curl -fsSL "https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz" -o /tmp/docker.tgz
+  tar -xzf /tmp/docker.tgz --strip-components=1 -C "${LOCAL_BIN}" docker/docker
+  rm /tmp/docker.tgz
+fi
+for _ in $(seq 1 30); do docker info >/dev/null 2>&1 && break; sleep 1; done
+
+# Build from the repo root (the Dockerfile copies v1/). Pass the version ldflags
+# the same way ./tools build-static does.
+docker build \
+  --build-arg "VERSION=${VERSION}" \
+  --build-arg "GIT_COMMIT=$(git rev-parse --short HEAD)" \
+  --build-arg "BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  -t "${IMAGE}:${VERSION}" .
+docker save "${IMAGE}:${VERSION}" -o /tmp/image.tar
+crane push /tmp/image.tar "${IMAGE}:${VERSION}"
+crane push /tmp/image.tar "${IMAGE}:latest"
+rm /tmp/image.tar
+
+echo "=== bump chart appVersion to ${VERSION} ==="
+sed -i "s/^appVersion: .*/appVersion: \"${VERSION}\"/" deploy/charts/foundry-gateway-controller/Chart.yaml
+git add deploy/charts/foundry-gateway-controller/Chart.yaml
+if ! git diff --cached --quiet; then
+  git commit -m "ci: bump foundry appVersion to ${VERSION}"
+  # release-helm may also be committing Chart.yaml (a different line); rebase to
+  # serialize cleanly before pushing.
+  git pull --rebase origin main || true
+  git push origin main
+fi
+
+echo "=== create GitHub release ${NEW_TAG} ==="
+if ! command -v gh >/dev/null 2>&1; then
+  curl -fsSL "https://github.com/cli/cli/releases/download/v${GHCLI_VERSION}/gh_${GHCLI_VERSION}_linux_amd64.tar.gz" -o /tmp/gh.tar.gz
+  tar -xzf /tmp/gh.tar.gz -C /tmp
+  cp "/tmp/gh_${GHCLI_VERSION}_linux_amd64/bin/gh" "${LOCAL_BIN}/gh"
+fi
+GH_TOKEN="${GITHUB_PAT}" gh release create "${NEW_TAG}" \
+  --repo "${REACTORCIDE_REPO}" \
+  --title "${NEW_TAG}" \
+  --generate-notes
+
+echo "=== released ${NEW_TAG} (image ${IMAGE}:${VERSION}) ==="

--- a/.reactorcide/jobs/test.yaml
+++ b/.reactorcide/jobs/test.yaml
@@ -1,0 +1,56 @@
+name: foundry-test
+description: "Build and run the Go unit tests (some use testcontainers, hence the docker capability)"
+triggers:
+  events:
+    - pull_request_opened
+    - pull_request_updated
+  branches:
+    - main
+paths:
+  include:
+    - "v1/**"
+    - "csil/**"        # a CSIL/contract change must still build + pass the suite
+job:
+  image: golang:1.25-bookworm
+  command: |
+    set -e
+    # Keep all writes in /tmp so the job runs identically under any uid (the
+    # worker's runner uid and `reactorcide run-local`'s host uid).
+    export HOME=/tmp/home GOCACHE=/tmp/gocache GOMODCACHE=/tmp/gomod GOPATH=/tmp/gopath
+    mkdir -p "$HOME" "$GOCACHE" "$GOMODCACHE" "$GOPATH"
+
+    # Several unit tests spin up containers via testcontainers-go, which talks to
+    # the Docker daemon exposed by the 'docker' capability. Disable Ryuk: the
+    # reaper does not behave well against a remote daemon in CI.
+    export TESTCONTAINERS_RYUK_DISABLED=true
+
+    if [ "${REACTORCIDE_WORKER_MODE:-remote}" = "local" ]; then
+      cd /job/src
+    else
+      git clone --branch "${REACTORCIDE_HEAD_REF:-$REACTORCIDE_PR_REF}" \
+        "${REACTORCIDE_HEAD_URL:-$REACTORCIDE_SOURCE_URL}" /job/src
+      cd /job/src
+    fi
+    cd v1
+
+    echo "=== gofmt check ==="
+    UNFORMATTED=$(gofmt -l .)
+    if [ -n "${UNFORMATTED}" ]; then
+      echo "These files are not gofmt-clean:"
+      echo "${UNFORMATTED}"
+      exit 1
+    fi
+
+    echo "=== go vet ==="
+    go vet ./...
+
+    echo "=== build ==="
+    go build ./...
+
+    echo "=== test ==="
+    go test ./...
+  timeout: 1800
+  priority: 10
+  capabilities:
+    - docker          # testcontainers-go needs a daemon (DOCKER_HOST)
+  raw_command: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+# syntax=docker/dockerfile:1
+#
+# Builds the foundry binary and packages it as a minimal container. The default
+# entrypoint runs the gateway controller, but any foundry subcommand can be run
+# by overriding the container args.
+#
+# Build context is the repository root:
+#   docker build -t foundry-gateway-controller \
+#     --build-arg VERSION=$(git describe --tags --always --dirty) \
+#     --build-arg GIT_COMMIT=$(git rev-parse --short HEAD) \
+#     --build-arg BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ) .
+
+FROM golang:1.25 AS build
+
+WORKDIR /src/v1
+
+# Download modules first so they are cached independently of source changes.
+COPY v1/go.mod v1/go.sum ./
+RUN go mod download
+
+# Build the static binary with the same ldflags as ./tools build-static.
+COPY v1/ ./
+ARG VERSION=dev
+ARG GIT_COMMIT=unknown
+ARG BUILD_DATE=unknown
+RUN CGO_ENABLED=0 go build \
+    -ldflags "-X main.Version=${VERSION} -X main.GitCommit=${GIT_COMMIT} -X main.BuildDate=${BUILD_DATE} -s -w" \
+    -o /out/foundry ./cmd/foundry
+
+# Minimal, non-root runtime. The static distroless image has no shell or
+# package manager, which keeps the attack surface small.
+FROM gcr.io/distroless/static:nonroot
+
+COPY --from=build /out/foundry /usr/local/bin/foundry
+
+USER nonroot:nonroot
+ENTRYPOINT ["/usr/local/bin/foundry"]
+CMD ["gateway", "controller"]

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ foundry/
 - [Configuration](./docs/configuration.md) - Configuration file format and management
 - [Secrets](./docs/secrets.md) - Secret management with instance scoping
 - [Hosts](./docs/hosts.md) - Infrastructure host management
+- [Gateway Controller](./docs/gateway-controller.md) - Route-driven L4 (TCP/TLS) listeners on the cluster VIP
 
 ## Quick Start
 

--- a/csil/v1/components/contour.csil
+++ b/csil/v1/components/contour.csil
@@ -21,5 +21,20 @@ Config = {
     service_monitor_enabled: bool @go_name("ServiceMonitorEnabled"),  ; Enable ServiceMonitor for Prometheus, default: true (requires CRD)
     create_gateway: bool @go_name("CreateGateway"),             ; Create GatewayClass and Gateway resources, default: true
     create_gateway_certificate: bool @go_name("CreateGatewayCertificate"), ; Create TLS Certificate for HTTPS listener, default: true
+    ? listeners: [* ContourListener] @go_name("Listeners"),     ; Additional L4 (TCP/TLS) listeners to add to the Gateway and expose on the Envoy service
     values: {* text => any},            ; Additional Helm values to pass to the chart
+}
+
+; A custom L4 listener added to the Contour Gateway and exposed on the Envoy
+; service (and thus the cluster VIP). Use protocol TLS (Passthrough) for
+; SNI-based routing via TLSRoute, or TCP for raw routing via TCPRoute.
+; Contour binds Envoy to (port + 8000) internally; Foundry handles the
+; service targetPort and NetworkPolicy mapping automatically.
+ContourListener = {
+    name: text @go_name("Name"),                    ; Unique listener name (also used for the service port name)
+    protocol: text @go_name("Protocol"),            ; "TLS" (Passthrough, for TLSRoute/SNI) or "TCP" (for TCPRoute)
+    port: uint @go_name("Port"),                    ; External port exposed on the VIP (e.g. 4987)
+    ? tls_mode: text @go_name("TLSMode"),           ; TLS listeners only: "Passthrough" (default) or "Terminate"
+    ? hostname: text @go_name("Hostname"),          ; Optional SNI hostname filter on the listener (TLS only)
+    ? certificate_ref: text @go_name("CertificateRef"), ; Secret name for TLS Terminate mode (ignored for Passthrough/TCP)
 }

--- a/deploy/charts/foundry-gateway-controller/.helmignore
+++ b/deploy/charts/foundry-gateway-controller/.helmignore
@@ -1,0 +1,6 @@
+.DS_Store
+.git/
+.gitignore
+*.tmp
+*.bak
+*.swp

--- a/deploy/charts/foundry-gateway-controller/Chart.yaml
+++ b/deploy/charts/foundry-gateway-controller/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v2
+name: foundry-gateway-controller
+description: |
+  Route-driven controller that opens L4 (TCP/TLS) listeners on the shared
+  Contour Gateway and the cluster VIP from TLSRoute/TCPRoute resources.
+type: application
+# Chart version; bump on chart changes (semver).
+version: 0.1.0
+# Version of the foundry binary this chart defaults to deploying.
+appVersion: "0.1.0"
+keywords:
+  - foundry
+  - gateway-api
+  - contour
+  - ingress
+home: https://github.com/catalystcommunity/foundry
+sources:
+  - https://github.com/catalystcommunity/foundry
+maintainers:
+  - name: Catalyst Community

--- a/deploy/charts/foundry-gateway-controller/README.md
+++ b/deploy/charts/foundry-gateway-controller/README.md
@@ -1,0 +1,53 @@
+# foundry-gateway-controller
+
+Deploys the Foundry **gateway controller** into a cluster. The controller watches
+`TLSRoute`/`TCPRoute` resources that target the Contour Gateway and opens the
+matching L4 listener on the Gateway, the corresponding port on the Envoy service
+(exposed on the cluster VIP via its `externalIPs`), and the matching ingress
+rule on the Envoy `NetworkPolicy`.
+
+This lets application charts declare their own ingress intent — a route with a
+`parentRef` port — without an operator editing the central Contour/Gateway
+config for every new port. See [docs/gateway-controller.md](../../../docs/gateway-controller.md)
+for the full design.
+
+## Install
+
+```bash
+helm install gateway-controller \
+  deploy/charts/foundry-gateway-controller \
+  --namespace foundry-system --create-namespace \
+  --set image.tag=<version>
+```
+
+The image defaults to `containers.catalystsquad.com/public/catalystcommunity/foundry`
+and the tag defaults to the chart `appVersion`.
+
+## Values
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `replicaCount` | `1` | Controller replicas (the reconcile is idempotent). |
+| `image.repository` | `containers.catalystsquad.com/public/catalystcommunity/foundry` | Image repository. |
+| `image.tag` | `""` (chart `appVersion`) | Image tag. |
+| `controller.gatewayName` | `contour` | Gateway to manage. |
+| `controller.gatewayNamespace` | `projectcontour` | Gateway / Envoy namespace. |
+| `controller.envoyService` | `contour-envoy` | Envoy service holding the VIP. |
+| `controller.networkPolicy` | `contour-envoy` | Envoy NetworkPolicy (`""` to skip). |
+| `controller.interval` | `15s` | Resync interval. |
+| `controller.extraArgs` | `[]` | Extra args appended to the command. |
+| `rbac.create` | `true` | Create the ClusterRole/Binding. |
+| `serviceAccount.create` | `true` | Create the ServiceAccount. |
+
+## RBAC
+
+The controller needs a ClusterRole (routes are read cluster-wide):
+
+- `gateway.networking.k8s.io`: `tlsroutes`, `tcproutes` — get/list/watch
+- `gateway.networking.k8s.io`: `gateways` — get/list/watch/update/patch
+- core `services` — get/list/watch/update/patch
+- `networking.k8s.io` `networkpolicies` — get/list/watch/update/patch
+
+The Gateway, Service and NetworkPolicy writes only ever touch the configured
+`gatewayNamespace`; if you want to tighten this, split those three resources
+into a namespaced Role and keep only the route read in the ClusterRole.

--- a/deploy/charts/foundry-gateway-controller/templates/NOTES.txt
+++ b/deploy/charts/foundry-gateway-controller/templates/NOTES.txt
@@ -1,0 +1,29 @@
+{{ include "foundry-gateway-controller.fullname" . }} is now running.
+
+It watches TLSRoute and TCPRoute resources targeting Gateway
+{{ .Values.controller.gatewayNamespace }}/{{ .Values.controller.gatewayName }} and opens the matching
+listener on the Gateway, the Envoy service ({{ .Values.controller.envoyService }}, on the cluster VIP),
+and the Envoy NetworkPolicy.
+
+To expose a service, create a route in your app's chart with a parentRef port, e.g.:
+
+  apiVersion: gateway.networking.k8s.io/v1alpha2
+  kind: TLSRoute
+  metadata:
+    name: my-app
+    namespace: my-app
+  spec:
+    parentRefs:
+      - name: {{ .Values.controller.gatewayName }}
+        namespace: {{ .Values.controller.gatewayNamespace }}
+        port: 4987
+    hostnames:
+      - my-app.example.com
+    rules:
+      - backendRefs:
+          - name: my-app
+            port: 4987
+
+Check the controller logs:
+
+  kubectl -n {{ .Release.Namespace }} logs deploy/{{ include "foundry-gateway-controller.fullname" . }} -f

--- a/deploy/charts/foundry-gateway-controller/templates/_helpers.tpl
+++ b/deploy/charts/foundry-gateway-controller/templates/_helpers.tpl
@@ -1,0 +1,49 @@
+{{/* Expand the name of the chart. */}}
+{{- define "foundry-gateway-controller.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/* Fully qualified app name. */}}
+{{- define "foundry-gateway-controller.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "foundry-gateway-controller.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "foundry-gateway-controller.labels" -}}
+helm.sh/chart: {{ include "foundry-gateway-controller.chart" . }}
+{{ include "foundry-gateway-controller.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "foundry-gateway-controller.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "foundry-gateway-controller.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "foundry-gateway-controller.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "foundry-gateway-controller.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{- define "foundry-gateway-controller.image" -}}
+{{- $tag := default .Chart.AppVersion .Values.image.tag -}}
+{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- end }}

--- a/deploy/charts/foundry-gateway-controller/templates/deployment.yaml
+++ b/deploy/charts/foundry-gateway-controller/templates/deployment.yaml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "foundry-gateway-controller.fullname" . }}
+  labels:
+    {{- include "foundry-gateway-controller.labels" . | nindent 4 }}
+spec:
+  # The reconcile is idempotent, but a single replica avoids redundant writes.
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "foundry-gateway-controller.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "foundry-gateway-controller.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "foundry-gateway-controller.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: controller
+          image: {{ include "foundry-gateway-controller.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - gateway
+            - controller
+            - --gateway-name={{ .Values.controller.gatewayName }}
+            - --gateway-namespace={{ .Values.controller.gatewayNamespace }}
+            - --envoy-service={{ .Values.controller.envoyService }}
+            - --network-policy={{ .Values.controller.networkPolicy }}
+            - --interval={{ .Values.controller.interval }}
+            {{- with .Values.controller.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/charts/foundry-gateway-controller/templates/rbac.yaml
+++ b/deploy/charts/foundry-gateway-controller/templates/rbac.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "foundry-gateway-controller.fullname" . }}
+  labels:
+    {{- include "foundry-gateway-controller.labels" . | nindent 4 }}
+rules:
+  # Discover the routes that declare desired listeners (cluster-wide).
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["tlsroutes", "tcproutes"]
+    verbs: ["get", "list", "watch"]
+  # Program listeners on the shared Gateway.
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["gateways"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  # Open the matching port on the Envoy service (the cluster VIP).
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  # Admit the remapped Envoy port through the Envoy NetworkPolicy.
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["networkpolicies"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "foundry-gateway-controller.fullname" . }}
+  labels:
+    {{- include "foundry-gateway-controller.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "foundry-gateway-controller.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "foundry-gateway-controller.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/deploy/charts/foundry-gateway-controller/templates/serviceaccount.yaml
+++ b/deploy/charts/foundry-gateway-controller/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "foundry-gateway-controller.serviceAccountName" . }}
+  labels:
+    {{- include "foundry-gateway-controller.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/charts/foundry-gateway-controller/values.yaml
+++ b/deploy/charts/foundry-gateway-controller/values.yaml
@@ -1,0 +1,63 @@
+# Default values for foundry-gateway-controller.
+
+replicaCount: 1
+
+image:
+  repository: containers.catalystsquad.com/public/catalystcommunity/foundry
+  # Defaults to the chart appVersion when empty.
+  tag: ""
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+nameOverride: ""
+fullnameOverride: ""
+
+# Controller behavior. These map directly to the `foundry gateway controller`
+# flags. The defaults match a Foundry-installed Contour.
+controller:
+  gatewayName: contour
+  gatewayNamespace: projectcontour
+  envoyService: contour-envoy
+  # Set to "" to skip NetworkPolicy reconciliation.
+  networkPolicy: contour-envoy
+  # Resync interval for the watch loop (Go duration).
+  interval: 15s
+  # Extra raw args appended to the controller command.
+  extraArgs: []
+
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+
+rbac:
+  # Create the ClusterRole and ClusterRoleBinding the controller needs.
+  create: true
+
+# Pod-level security context. The image runs as a non-root distroless binary.
+podSecurityContext:
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+
+resources:
+  requests:
+    cpu: 10m
+    memory: 32Mi
+  limits:
+    cpu: 100m
+    memory: 128Mi
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+podAnnotations: {}
+podLabels: {}

--- a/docs/gateway-controller.md
+++ b/docs/gateway-controller.md
@@ -1,0 +1,142 @@
+# Gateway Controller
+
+The gateway controller lets application charts open L4 (TCP/TLS) listeners on the
+shared Contour Gateway — and on the cluster VIP — purely by declaring a route in
+their own chart. No operator has to edit the central Contour configuration for
+each new port.
+
+## Why
+
+Foundry installs Contour with a single, statically-provisioned Envoy that holds
+the cluster VIP (via `externalIPs` on the `contour-envoy` Service). Opening a new
+port on that shared data plane normally requires three coordinated changes that
+only an operator can make:
+
+1. add a listener to the `contour` Gateway,
+2. add the port to the `contour-envoy` Service (so the VIP answers on it), and
+3. allow the port through the Envoy `NetworkPolicy`.
+
+Gateway API splits ownership on purpose — the operator owns the **Gateway**
+(listeners/ports), and the app owns the **route** (hostname → service). The
+controller automates the operator half: it derives the needed listeners from the
+routes themselves, so an app team only writes a route.
+
+> For UDP, Contour has no support — expose it with a plain Service that lists the
+> VIP in `externalIPs`. See the "Alternatives" section.
+
+## The model
+
+An app declares intent with a `TLSRoute` or `TCPRoute` whose `parentRefs` target
+the Contour Gateway **with a port**:
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TLSRoute
+metadata:
+  name: linkkeys
+  namespace: linkkeys
+spec:
+  parentRefs:
+    - name: contour
+      namespace: projectcontour
+      port: 4987            # the port the controller opens
+  hostnames:
+    - linkkeys.example.com  # routed by SNI (TLS passthrough)
+  rules:
+    - backendRefs:
+        - name: linkkeys
+          port: 4987
+```
+
+The controller reads the `port` from `parentRefs` and the protocol from the route
+kind:
+
+| Route kind | Listener protocol | Routing |
+| --- | --- | --- |
+| `TLSRoute` | `TLS` (Passthrough) | by **SNI** — TLS terminates at the backend |
+| `TCPRoute` | `TCP` | by **port** only (no hostname) |
+
+Multiple `TLSRoute`s can share one listener/port and are disambiguated by SNI, so
+two domains on port 4987 each terminate TLS at their own backend.
+
+## What it reconciles
+
+For every desired `(port, protocol)`, the controller converges three resources in
+the Gateway namespace:
+
+1. **Gateway listener** — named `gw-<proto>-<port>` (e.g. `gw-tls-4987`), with
+   `allowedRoutes` for the matching route kind and `from: All`.
+2. **`contour-envoy` Service port** — `port` → `targetPort = port + 8000`. Contour
+   binds Envoy to the listener port plus 8000 (80→8080, 443→8443, 4987→12987); the
+   port is reachable on the VIP automatically through the existing `externalIPs`.
+3. **Envoy `NetworkPolicy` ingress** — admits the remapped target port (the default
+   policy only allows 8080/8443/8002).
+
+It owns only what it creates: `gw-`prefixed listeners/ports, and NetworkPolicy
+ports recorded in the `gateway.foundry.dev/managed-target-ports` annotation. The
+built-in HTTP/HTTPS listeners and any operator-pinned static listeners are never
+touched. Deleting a route prunes its port. Because it reconciles continuously, it
+also re-applies itself after a `foundry stack install`/upgrade resets the Service.
+
+Ports **80** and **443** are reserved for the built-in listeners and are refused.
+A port requested as both TLS and TCP is skipped with a logged conflict.
+
+## Running it
+
+### As a CLI (local / ad hoc)
+
+```bash
+foundry gateway controller            # watch loop, 15s resync (Ctrl-C to stop)
+foundry gateway controller --once     # single reconcile pass, then exit
+```
+
+Flags: `--gateway-name`, `--gateway-namespace`, `--envoy-service`,
+`--network-policy` (empty to skip), `--interval`, `--kubeconfig`.
+
+Client config resolves in order: `--kubeconfig` → in-cluster service account (when
+running as a pod) → `~/.foundry/kubeconfig`.
+
+### In-cluster (Helm chart)
+
+A container image and chart are provided. Build and push the image, then install:
+
+```bash
+# Build (from the repo root)
+docker build -t containers.catalystsquad.com/public/catalystcommunity/foundry:<version> \
+  --build-arg VERSION=<version> .
+
+# Deploy
+helm install gateway-controller \
+  deploy/charts/foundry-gateway-controller \
+  --namespace foundry-system --create-namespace \
+  --set image.tag=<version>
+```
+
+The chart creates a single-replica Deployment, a ServiceAccount, and a ClusterRole/
+Binding. See [deploy/charts/foundry-gateway-controller/README.md](../deploy/charts/foundry-gateway-controller/README.md)
+for all values.
+
+CI builds and publishes both the image and the chart on merge to `main` via
+reactorcide (see `.reactorcide/jobs/`), so you normally just bump a route — the
+image/chart releases are automated.
+
+### RBAC
+
+The controller reads routes cluster-wide and writes only to the Gateway namespace:
+
+- `gateway.networking.k8s.io`: `tlsroutes`, `tcproutes` — get/list/watch
+- `gateway.networking.k8s.io`: `gateways` — get/list/watch/update/patch
+- core `services` — get/list/watch/update/patch
+- `networking.k8s.io` `networkpolicies` — get/list/watch/update/patch
+
+## Alternatives
+
+- **Static operator-pinned listeners.** If a port should always be open regardless
+  of routes, declare it once under `components.contour.listeners` in the stack
+  config — each entry has `name`, `protocol` (`TCP`/`TLS`), `port`, and optional
+  `tls_mode`/`hostname`/`certificate_ref`. Foundry opens it during
+  `stack install` (Gateway listener + Envoy service port + NetworkPolicy). The
+  controller leaves these untouched — the two coexist.
+- **UDP.** Contour does not implement `UDPRoute`. Expose UDP with a plain Service
+  that lists the VIP in `externalIPs` and a `protocol: UDP` port, owned by the
+  app's chart. It bypasses the Gateway entirely.

--- a/v1/cmd/foundry/commands/gateway/commands.go
+++ b/v1/cmd/foundry/commands/gateway/commands.go
@@ -1,0 +1,148 @@
+package gateway
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"github.com/catalystcommunity/foundry/v1/internal/config"
+	"github.com/catalystcommunity/foundry/v1/internal/gateway"
+	"github.com/catalystcommunity/foundry/v1/internal/k8s"
+	"github.com/urfave/cli/v3"
+)
+
+// Command is the top-level gateway command.
+var Command = &cli.Command{
+	Name:  "gateway",
+	Usage: "Manage the cluster ingress Gateway",
+	Commands: []*cli.Command{
+		ControllerCommand,
+	},
+}
+
+// ControllerCommand runs the route-driven listener reconciler.
+var ControllerCommand = &cli.Command{
+	Name:  "controller",
+	Usage: "Open Gateway listeners on the VIP from TLSRoute/TCPRoute resources",
+	Description: "Watches TLSRoute and TCPRoute resources that target the Contour Gateway and " +
+		"opens the matching L4 listener, Envoy service port (on the cluster VIP), and Envoy " +
+		"NetworkPolicy ingress. Apps declare a route with a parentRef port in their own chart; " +
+		"this controller handles the data-plane plumbing. Listeners it creates are named with a " +
+		"'gw-' prefix and pruned when their routes are removed; the built-in HTTP/HTTPS and any " +
+		"operator-pinned static listeners are left untouched.",
+	Flags: []cli.Flag{
+		&cli.StringFlag{Name: "gateway-name", Value: "contour", Usage: "name of the Gateway to manage"},
+		&cli.StringFlag{Name: "gateway-namespace", Value: "projectcontour", Usage: "namespace of the Gateway and Envoy service"},
+		&cli.StringFlag{Name: "envoy-service", Value: "contour-envoy", Usage: "name of the Envoy LoadBalancer/VIP service"},
+		&cli.StringFlag{Name: "network-policy", Value: "contour-envoy", Usage: "name of the Envoy NetworkPolicy (empty to skip)"},
+		&cli.DurationFlag{Name: "interval", Value: 15 * time.Second, Usage: "resync interval for the watch loop"},
+		&cli.BoolFlag{Name: "once", Usage: "run a single reconcile pass and exit"},
+		&cli.StringFlag{Name: "kubeconfig", Usage: "path to kubeconfig (default: in-cluster when running as a pod, else ~/.foundry/kubeconfig)"},
+	},
+	Action: runController,
+}
+
+func runController(ctx context.Context, cmd *cli.Command) error {
+	k8sClient, err := newClusterClient(cmd.String("kubeconfig"))
+	if err != nil {
+		return err
+	}
+
+	opts := gateway.Options{
+		GatewayName:      cmd.String("gateway-name"),
+		GatewayNamespace: cmd.String("gateway-namespace"),
+		EnvoyService:     cmd.String("envoy-service"),
+		NetworkPolicy:    cmd.String("network-policy"),
+	}
+
+	reconcileOnce := func(ctx context.Context) error {
+		result, err := gateway.Reconcile(ctx, k8sClient.DynamicClient(), k8sClient.Clientset(), opts)
+		if err != nil {
+			return err
+		}
+		reportResult(result)
+		return nil
+	}
+
+	if cmd.Bool("once") {
+		return reconcileOnce(ctx)
+	}
+
+	// Long-running watch loop: reconcile on a fixed interval, exiting cleanly on
+	// SIGINT/SIGTERM. Transient reconcile errors are logged but don't stop the
+	// controller.
+	ctx, stop := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	interval := cmd.Duration("interval")
+	fmt.Printf("Gateway controller watching routes for Gateway %s/%s (resync %s)\n",
+		opts.GatewayNamespace, opts.GatewayName, interval)
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	if err := reconcileOnce(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "  ⚠ reconcile failed: %v\n", err)
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			fmt.Println("Gateway controller stopped")
+			return nil
+		case <-ticker.C:
+			if err := reconcileOnce(ctx); err != nil {
+				fmt.Fprintf(os.Stderr, "  ⚠ reconcile failed: %v\n", err)
+			}
+		}
+	}
+}
+
+// newClusterClient builds a Kubernetes client, resolving its configuration in
+// this order: an explicit --kubeconfig path, then the in-cluster service
+// account (when running as a pod), then the Foundry-managed kubeconfig at
+// ~/.foundry/kubeconfig (matching the other cluster commands).
+func newClusterClient(kubeconfigOverride string) (*k8s.Client, error) {
+	if kubeconfigOverride != "" {
+		return clientFromFile(kubeconfigOverride)
+	}
+
+	// Running as a pod: use the mounted service account.
+	if os.Getenv("KUBERNETES_SERVICE_HOST") != "" {
+		return k8s.NewClientInCluster()
+	}
+
+	configDir, err := config.GetConfigDir()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get config directory: %w", err)
+	}
+	return clientFromFile(filepath.Join(configDir, "kubeconfig"))
+}
+
+func clientFromFile(path string) (*k8s.Client, error) {
+	kubeconfigBytes, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read kubeconfig at %s: %w", path, err)
+	}
+	k8sClient, err := k8s.NewClientFromKubeconfig(kubeconfigBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create k8s client: %w", err)
+	}
+	return k8sClient, nil
+}
+
+func reportResult(result *gateway.Result) {
+	for _, conflict := range result.Conflicts {
+		fmt.Printf("  ⚠ %s\n", conflict)
+	}
+	if result.Changed() {
+		fmt.Printf("  ✓ reconciled (gateway=%t service=%t networkpolicy=%t)\n",
+			result.GatewayUpdated, result.ServiceUpdated, result.NetworkPolicyUpdated)
+		for _, d := range result.Desired {
+			fmt.Printf("    • %s listener on port %d → envoy %d\n", d.Protocol, d.Port, gateway.TargetPortFor(d.Port))
+		}
+	}
+}

--- a/v1/cmd/foundry/main.go
+++ b/v1/cmd/foundry/main.go
@@ -11,6 +11,7 @@ import (
 	configcmd "github.com/catalystcommunity/foundry/v1/cmd/foundry/commands/config"
 	dashboardcmd "github.com/catalystcommunity/foundry/v1/cmd/foundry/commands/dashboard"
 	dnscmd "github.com/catalystcommunity/foundry/v1/cmd/foundry/commands/dns"
+	gatewaycmd "github.com/catalystcommunity/foundry/v1/cmd/foundry/commands/gateway"
 	grafanacmd "github.com/catalystcommunity/foundry/v1/cmd/foundry/commands/grafana"
 	hostcmd "github.com/catalystcommunity/foundry/v1/cmd/foundry/commands/host"
 	logscmd "github.com/catalystcommunity/foundry/v1/cmd/foundry/commands/logs"
@@ -73,6 +74,7 @@ func main() {
 			configcmd.Command,
 			dashboardcmd.Command,
 			dnscmd.Command,
+			gatewaycmd.Command,
 			grafanacmd.Command,
 			hostcmd.Command,
 			logscmd.Command,

--- a/v1/internal/component/contour/install.go
+++ b/v1/internal/component/contour/install.go
@@ -3,6 +3,7 @@ package contour
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/catalystcommunity/foundry/v1/internal/helm"
@@ -24,6 +25,11 @@ func Install(ctx context.Context, helmClient HelmClient, k8sClient K8sClient, cf
 	}
 	if cfg == nil {
 		cfg = DefaultConfig()
+	}
+
+	// Validate custom L4 listeners before touching the cluster
+	if err := cfg.ValidateListeners(); err != nil {
+		return fmt.Errorf("invalid listener configuration: %w", err)
 	}
 
 	// Check for ServiceMonitor CRD if ServiceMonitor is enabled
@@ -187,11 +193,8 @@ func buildHelmValues(cfg *Config) map[string]interface{} {
 	values["contour"] = contourConfig
 
 	// Configure Envoy
-	envoyConfig := map[string]interface{}{
-		"replicas": cfg.EnvoyReplicaCount,
-		"service": map[string]interface{}{
-			"type": "LoadBalancer",
-		},
+	serviceConfig := map[string]interface{}{
+		"type": "LoadBalancer",
 	}
 
 	// Configure for bare metal with kube-vip
@@ -204,15 +207,54 @@ func buildHelmValues(cfg *Config) map[string]interface{} {
 			// and service leader advertise the same IP on different nodes.
 			// See: https://github.com/kube-vip/kube-vip/issues/665
 			//
-			// With externalIPs, Kubernetes routes traffic to the VIP (ports 80/443) directly
-			// to envoy pods via kube-proxy, while kube-vip manages only the CP VIP (port 6443).
-			envoyConfig["service"] = map[string]interface{}{
+			// With externalIPs, Kubernetes routes traffic to the VIP directly to envoy
+			// pods via kube-proxy (for every port on the service, including extraPorts),
+			// while kube-vip manages only the CP VIP (port 6443).
+			serviceConfig = map[string]interface{}{
 				"type":        "ClusterIP",
 				"externalIPs": []string{vip},
 			}
 		}
 		// If no VIP is set, keep default LoadBalancer type for kube-vip to auto-assign
 	}
+
+	envoyConfig := map[string]interface{}{
+		"replicas": cfg.EnvoyReplicaCount,
+		"service":  serviceConfig,
+	}
+
+	// Expose any custom L4 listeners. Each needs three things wired up:
+	//   1. service.extraPorts so the port is reachable on the service/VIP. The
+	//      targetPort is the remapped Envoy container port (listener port + 8000).
+	//   2. networkPolicy.extraIngress so the default policy (which only admits
+	//      8080/8443/8002) doesn't drop traffic to the remapped port.
+	// The Gateway listener itself is created separately (see generateGatewayManifest).
+	if len(cfg.Listeners) > 0 {
+		extraPorts := make([]interface{}, 0, len(cfg.Listeners))
+		extraIngress := make([]interface{}, 0, len(cfg.Listeners))
+		for _, l := range cfg.Listeners {
+			targetPort := l.EnvoyContainerPort()
+			extraPorts = append(extraPorts, map[string]interface{}{
+				"name":       l.Name,
+				"port":       l.Port,
+				"targetPort": targetPort,
+				"protocol":   "TCP",
+			})
+			extraIngress = append(extraIngress, map[string]interface{}{
+				"ports": []interface{}{
+					map[string]interface{}{
+						"port":     targetPort,
+						"protocol": "TCP",
+					},
+				},
+			})
+		}
+		serviceConfig["extraPorts"] = extraPorts
+		envoyConfig["networkPolicy"] = map[string]interface{}{
+			"extraIngress": extraIngress,
+		}
+	}
+
 	values["envoy"] = envoyConfig
 
 	// Gateway API CRDs are managed by our gateway-api component, not the Contour chart
@@ -319,12 +361,15 @@ func createGatewayResources(ctx context.Context, k8sClient K8sClient, cfg *Confi
 		fmt.Println("    Re-run 'foundry stack install' after cert-manager is installed to add HTTPS support")
 	}
 
-	// Create Gateway (with HTTPS only if certificate was created)
-	gatewayManifest := generateGatewayManifest(cfg.Namespace, domain, createTLS)
+	// Create Gateway (with HTTPS only if certificate was created, plus any custom L4 listeners)
+	gatewayManifest := generateGatewayManifest(cfg.Namespace, domain, createTLS, cfg.Listeners)
 	if err := k8sClient.ApplyManifest(ctx, gatewayManifest); err != nil {
 		return fmt.Errorf("failed to create Gateway: %w", err)
 	}
 	fmt.Println("  ✓ Gateway 'contour' created")
+	for _, l := range cfg.Listeners {
+		fmt.Printf("    • listener %q (%s) on port %d\n", l.Name, l.Protocol, l.Port)
+	}
 
 	return nil
 }
@@ -377,8 +422,9 @@ spec:
 `, namespace, domain, domain)
 }
 
-// generateGatewayManifest generates the Gateway manifest with HTTP and HTTPS listeners
-func generateGatewayManifest(namespace, domain string, withTLS bool) string {
+// generateGatewayManifest generates the Gateway manifest with HTTP and HTTPS
+// listeners, plus any custom L4 (TCP/TLS) listeners.
+func generateGatewayManifest(namespace, domain string, withTLS bool, listeners []ContourListener) string {
 	// Base Gateway with HTTP listener
 	manifest := fmt.Sprintf(`apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
@@ -412,5 +458,43 @@ spec:
 `, domain)
 	}
 
+	// Add custom L4 listeners
+	for _, l := range listeners {
+		manifest += generateCustomListener(l)
+	}
+
 	return manifest
+}
+
+// generateCustomListener generates a single Gateway listener block for a
+// custom TCP or TLS listener. TLS listeners default to Passthrough mode and
+// allow TLSRoute (for SNI-based routing); TCP listeners allow TCPRoute.
+func generateCustomListener(l ContourListener) string {
+	b := &strings.Builder{}
+	fmt.Fprintf(b, "  - name: %s\n", l.Name)
+	fmt.Fprintf(b, "    port: %d\n", l.Port)
+
+	if l.Protocol == ListenerProtocolTLS {
+		b.WriteString("    protocol: TLS\n")
+		if l.Hostname != nil && *l.Hostname != "" {
+			fmt.Fprintf(b, "    hostname: %q\n", *l.Hostname)
+		}
+		b.WriteString("    tls:\n")
+		fmt.Fprintf(b, "      mode: %s\n", l.EffectiveTLSMode())
+		if l.EffectiveTLSMode() == TLSModeTerminate && l.CertificateRef != nil {
+			b.WriteString("      certificateRefs:\n")
+			fmt.Fprintf(b, "      - name: %s\n", *l.CertificateRef)
+		}
+		b.WriteString("    allowedRoutes:\n")
+		b.WriteString("      kinds:\n")
+		b.WriteString("      - kind: TLSRoute\n")
+	} else {
+		b.WriteString("    protocol: TCP\n")
+		b.WriteString("    allowedRoutes:\n")
+		b.WriteString("      kinds:\n")
+		b.WriteString("      - kind: TCPRoute\n")
+	}
+	b.WriteString("      namespaces:\n")
+	b.WriteString("        from: All\n")
+	return b.String()
 }

--- a/v1/internal/component/contour/install_test.go
+++ b/v1/internal/component/contour/install_test.go
@@ -552,7 +552,7 @@ func TestGenerateGatewayCertificateManifest(t *testing.T) {
 }
 
 func TestGenerateGatewayManifest_HTTPOnly(t *testing.T) {
-	manifest := generateGatewayManifest("projectcontour", "", false)
+	manifest := generateGatewayManifest("projectcontour", "", false, nil)
 
 	assert.Contains(t, manifest, "apiVersion: gateway.networking.k8s.io/v1")
 	assert.Contains(t, manifest, "kind: Gateway")
@@ -566,7 +566,7 @@ func TestGenerateGatewayManifest_HTTPOnly(t *testing.T) {
 }
 
 func TestGenerateGatewayManifest_WithHTTPS(t *testing.T) {
-	manifest := generateGatewayManifest("projectcontour", "catalyst.local", true)
+	manifest := generateGatewayManifest("projectcontour", "catalyst.local", true, nil)
 
 	assert.Contains(t, manifest, "name: http")
 	assert.Contains(t, manifest, "port: 80")
@@ -577,4 +577,109 @@ func TestGenerateGatewayManifest_WithHTTPS(t *testing.T) {
 	assert.Contains(t, manifest, "hostname: \"*.catalyst.local\"")
 	assert.Contains(t, manifest, "gateway-wildcard-tls")
 	assert.Contains(t, manifest, "mode: Terminate")
+}
+
+func strPtr(s string) *string { return &s }
+
+func TestGenerateGatewayManifest_TLSPassthroughListener(t *testing.T) {
+	listeners := []ContourListener{
+		{Name: "linkkeys-tls", Protocol: ListenerProtocolTLS, Port: 4987},
+	}
+	manifest := generateGatewayManifest("projectcontour", "", false, listeners)
+
+	assert.Contains(t, manifest, "name: linkkeys-tls")
+	assert.Contains(t, manifest, "port: 4987")
+	assert.Contains(t, manifest, "protocol: TLS")
+	assert.Contains(t, manifest, "mode: Passthrough")
+	assert.Contains(t, manifest, "kind: TLSRoute")
+	assert.Contains(t, manifest, "from: All")
+	// Passthrough must not emit certificateRefs
+	assert.NotContains(t, manifest, "certificateRefs")
+}
+
+func TestGenerateGatewayManifest_TCPListener(t *testing.T) {
+	listeners := []ContourListener{
+		{Name: "raw-tcp", Protocol: ListenerProtocolTCP, Port: 6000},
+	}
+	manifest := generateGatewayManifest("projectcontour", "", false, listeners)
+
+	assert.Contains(t, manifest, "name: raw-tcp")
+	assert.Contains(t, manifest, "port: 6000")
+	assert.Contains(t, manifest, "kind: TCPRoute")
+	// TCP listener has no tls block
+	assert.NotContains(t, manifest, "mode: Passthrough")
+}
+
+func TestGenerateGatewayManifest_TLSWithHostnameAndTerminate(t *testing.T) {
+	listeners := []ContourListener{
+		{
+			Name:           "termd",
+			Protocol:       ListenerProtocolTLS,
+			Port:           8888,
+			TLSMode:        strPtr(TLSModeTerminate),
+			Hostname:       strPtr("svc.example.com"),
+			CertificateRef: strPtr("my-cert"),
+		},
+	}
+	manifest := generateGatewayManifest("projectcontour", "", false, listeners)
+
+	assert.Contains(t, manifest, "hostname: \"svc.example.com\"")
+	assert.Contains(t, manifest, "mode: Terminate")
+	assert.Contains(t, manifest, "certificateRefs")
+	assert.Contains(t, manifest, "name: my-cert")
+}
+
+func TestBuildHelmValues_ListenersExtraPortsAndNetworkPolicy(t *testing.T) {
+	SetClusterVIP("10.16.0.30")
+	defer SetClusterVIP("")
+
+	cfg := DefaultConfig()
+	cfg.Listeners = []ContourListener{
+		{Name: "linkkeys-tls", Protocol: ListenerProtocolTLS, Port: 4987},
+	}
+	values := buildHelmValues(cfg)
+
+	envoy := values["envoy"].(map[string]interface{})
+	service := envoy["service"].(map[string]interface{})
+
+	// VIP still wired via externalIPs
+	assert.Equal(t, "ClusterIP", service["type"])
+	assert.Equal(t, []string{"10.16.0.30"}, service["externalIPs"])
+
+	// extraPorts: external 4987 -> remapped envoy target 12987
+	extraPorts := service["extraPorts"].([]interface{})
+	require.Len(t, extraPorts, 1)
+	port := extraPorts[0].(map[string]interface{})
+	assert.Equal(t, "linkkeys-tls", port["name"])
+	assert.Equal(t, uint64(4987), port["port"])
+	assert.Equal(t, uint64(12987), port["targetPort"])
+	assert.Equal(t, "TCP", port["protocol"])
+
+	// networkPolicy must admit the remapped port or traffic is dropped
+	np := envoy["networkPolicy"].(map[string]interface{})
+	extraIngress := np["extraIngress"].([]interface{})
+	require.Len(t, extraIngress, 1)
+	rule := extraIngress[0].(map[string]interface{})
+	rulePorts := rule["ports"].([]interface{})
+	require.Len(t, rulePorts, 1)
+	assert.Equal(t, uint64(12987), rulePorts[0].(map[string]interface{})["port"])
+}
+
+func TestBuildHelmValues_NoListeners_NoExtraPorts(t *testing.T) {
+	SetClusterVIP("")
+	cfg := DefaultConfig()
+	values := buildHelmValues(cfg)
+
+	envoy := values["envoy"].(map[string]interface{})
+	service := envoy["service"].(map[string]interface{})
+	_, hasExtraPorts := service["extraPorts"]
+	assert.False(t, hasExtraPorts)
+	_, hasNetPol := envoy["networkPolicy"]
+	assert.False(t, hasNetPol)
+}
+
+func TestEnvoyContainerPort_Remap(t *testing.T) {
+	assert.Equal(t, uint64(8080), ContourListener{Port: 80}.EnvoyContainerPort())
+	assert.Equal(t, uint64(8443), ContourListener{Port: 443}.EnvoyContainerPort())
+	assert.Equal(t, uint64(12987), ContourListener{Port: 4987}.EnvoyContainerPort())
 }

--- a/v1/internal/component/contour/types.gen.go
+++ b/v1/internal/component/contour/types.gen.go
@@ -5,15 +5,27 @@ package contour
 
 // Config represents a structured data type
 type Config struct {
-	Version                  string         `json:"version" yaml:"version"`
-	Namespace                string         `json:"namespace" yaml:"namespace"`
-	ReplicaCount             uint64         `json:"replica_count" yaml:"replica_count"`
-	EnvoyReplicaCount        uint64         `json:"envoy_replica_count" yaml:"envoy_replica_count"`
-	UseKubeVIP               bool           `json:"use_kubevip" yaml:"use_kubevip"`
-	DefaultIngressClass      bool           `json:"default_ingress_class" yaml:"default_ingress_class"`
-	GatewayAPIVersion        string         `json:"gateway_api_version" yaml:"gateway_api_version"`
-	ServiceMonitorEnabled    bool           `json:"service_monitor_enabled" yaml:"service_monitor_enabled"`
-	CreateGateway            bool           `json:"create_gateway" yaml:"create_gateway"`
-	CreateGatewayCertificate bool           `json:"create_gateway_certificate" yaml:"create_gateway_certificate"`
-	Values                   map[string]any `json:"values" yaml:",inline"`
+	Version                  string            `json:"version" yaml:"version"`
+	Namespace                string            `json:"namespace" yaml:"namespace"`
+	ReplicaCount             uint64            `json:"replica_count" yaml:"replica_count"`
+	EnvoyReplicaCount        uint64            `json:"envoy_replica_count" yaml:"envoy_replica_count"`
+	UseKubeVIP               bool              `json:"use_kubevip" yaml:"use_kubevip"`
+	DefaultIngressClass      bool              `json:"default_ingress_class" yaml:"default_ingress_class"`
+	GatewayAPIVersion        string            `json:"gateway_api_version" yaml:"gateway_api_version"`
+	ServiceMonitorEnabled    bool              `json:"service_monitor_enabled" yaml:"service_monitor_enabled"`
+	CreateGateway            bool              `json:"create_gateway" yaml:"create_gateway"`
+	CreateGatewayCertificate bool              `json:"create_gateway_certificate" yaml:"create_gateway_certificate"`
+	Listeners                []ContourListener `json:"listeners,omitempty" yaml:"listeners,omitempty"`
+	Values                   map[string]any    `json:"values" yaml:",inline"`
+}
+
+// ContourListener represents a custom L4 (TCP/TLS) listener added to the
+// Contour Gateway and exposed on the Envoy service.
+type ContourListener struct {
+	Name           string  `json:"name" yaml:"name"`
+	Protocol       string  `json:"protocol" yaml:"protocol"`
+	Port           uint64  `json:"port" yaml:"port"`
+	TLSMode        *string `json:"tls_mode,omitempty" yaml:"tls_mode,omitempty"`
+	Hostname       *string `json:"hostname,omitempty" yaml:"hostname,omitempty"`
+	CertificateRef *string `json:"certificate_ref,omitempty" yaml:"certificate_ref,omitempty"`
 }

--- a/v1/internal/component/contour/types.go
+++ b/v1/internal/component/contour/types.go
@@ -234,6 +234,41 @@ func ParseConfig(cfg component.ComponentConfig) (*Config, error) {
 		config.CreateGatewayCertificate = createGatewayCertificate
 	}
 
+	// Additional L4 (TCP/TLS) listeners
+	if raw, ok := cfg.Get("listeners"); ok {
+		if listeners, ok := raw.([]interface{}); ok {
+			for _, entry := range listeners {
+				m, ok := entry.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				l := ContourListener{}
+				if name, ok := m["name"].(string); ok {
+					l.Name = name
+				}
+				if protocol, ok := m["protocol"].(string); ok {
+					l.Protocol = protocol
+				}
+				switch port := m["port"].(type) {
+				case int:
+					l.Port = uint64(port)
+				case float64:
+					l.Port = uint64(port)
+				}
+				if tlsMode, ok := m["tls_mode"].(string); ok {
+					l.TLSMode = &tlsMode
+				}
+				if hostname, ok := m["hostname"].(string); ok {
+					l.Hostname = &hostname
+				}
+				if certRef, ok := m["certificate_ref"].(string); ok {
+					l.CertificateRef = &certRef
+				}
+				config.Listeners = append(config.Listeners, l)
+			}
+		}
+	}
+
 	if values, ok := cfg.GetMap("values"); ok {
 		config.Values = values
 	}
@@ -249,4 +284,96 @@ func ParseConfig(cfg component.ComponentConfig) (*Config, error) {
 	}
 
 	return config, nil
+}
+
+// Listener protocol values supported for custom L4 listeners.
+const (
+	ListenerProtocolTCP = "TCP"
+	ListenerProtocolTLS = "TLS"
+
+	// TLSModePassthrough routes by SNI without terminating TLS (use with TLSRoute).
+	TLSModePassthrough = "Passthrough"
+	// TLSModeTerminate terminates TLS at the Gateway (requires a certificate secret).
+	TLSModeTerminate = "Terminate"
+
+	// envoyPortOffset is the fixed offset Contour applies when mapping a Gateway
+	// listener port to the Envoy container port. See:
+	// https://projectcontour.io/docs/main/config/gateway-api/
+	envoyPortOffset = 8000
+)
+
+// EffectiveTLSMode returns the TLS mode for a listener, defaulting to
+// Passthrough when unset. Meaningless for TCP listeners.
+func (l ContourListener) EffectiveTLSMode() string {
+	if l.TLSMode != nil && *l.TLSMode != "" {
+		return *l.TLSMode
+	}
+	return TLSModePassthrough
+}
+
+// EnvoyContainerPort returns the port Envoy actually binds for this listener.
+func (l ContourListener) EnvoyContainerPort() uint64 {
+	return EnvoyContainerPort(l.Port)
+}
+
+// EnvoyContainerPort returns the port Envoy binds for a given Gateway listener
+// port. Contour maps a listener port by adding 8000, wrapping above 65535 and
+// lifting privileged results above 1023. This is the single source of truth for
+// the remap, shared by the static listener config and the gateway controller.
+func EnvoyContainerPort(listenerPort uint64) uint64 {
+	p := listenerPort + envoyPortOffset
+	if p > 65535 {
+		p -= 65535
+	}
+	if p <= 1023 {
+		p += 1023
+	}
+	return p
+}
+
+// ValidateListeners checks that each custom listener is well-formed and that
+// names and ports do not collide (including with the built-in HTTP/HTTPS ports).
+func (c *Config) ValidateListeners() error {
+	seenNames := map[string]bool{}
+	seenPorts := map[uint64]bool{
+		80:  true, // built-in HTTP listener
+		443: true, // built-in HTTPS listener
+	}
+	for i, l := range c.Listeners {
+		if l.Name == "" {
+			return fmt.Errorf("listener[%d]: name is required", i)
+		}
+		if seenNames[l.Name] {
+			return fmt.Errorf("listener %q: duplicate name", l.Name)
+		}
+		seenNames[l.Name] = true
+
+		switch l.Protocol {
+		case ListenerProtocolTCP, ListenerProtocolTLS:
+		default:
+			return fmt.Errorf("listener %q: protocol must be %q or %q, got %q",
+				l.Name, ListenerProtocolTCP, ListenerProtocolTLS, l.Protocol)
+		}
+
+		if l.Port < 1 || l.Port > 65535 {
+			return fmt.Errorf("listener %q: port %d out of range (1-65535)", l.Name, l.Port)
+		}
+		if seenPorts[l.Port] {
+			return fmt.Errorf("listener %q: port %d already in use (80/443 are reserved for the built-in HTTP/HTTPS listeners)", l.Name, l.Port)
+		}
+		seenPorts[l.Port] = true
+
+		if l.Protocol == ListenerProtocolTLS {
+			switch l.EffectiveTLSMode() {
+			case TLSModePassthrough:
+			case TLSModeTerminate:
+				if l.CertificateRef == nil || *l.CertificateRef == "" {
+					return fmt.Errorf("listener %q: certificate_ref is required for TLS Terminate mode", l.Name)
+				}
+			default:
+				return fmt.Errorf("listener %q: tls_mode must be %q or %q", l.Name, TLSModePassthrough, TLSModeTerminate)
+			}
+		}
+	}
+	return nil
 }

--- a/v1/internal/component/contour/types_test.go
+++ b/v1/internal/component/contour/types_test.go
@@ -242,3 +242,114 @@ func TestComponent_Status_PodsFetchError(t *testing.T) {
 	assert.False(t, status.Healthy)
 	assert.Contains(t, status.Message, "failed to get pods")
 }
+
+func TestParseConfig_Listeners(t *testing.T) {
+	cfg := component.ComponentConfig{
+		"listeners": []interface{}{
+			map[string]interface{}{
+				"name":     "linkkeys-tls",
+				"protocol": "TLS",
+				"port":     4987,
+			},
+			map[string]interface{}{
+				"name":            "termd",
+				"protocol":        "TLS",
+				"port":            float64(8888), // JSON-decoded numbers arrive as float64
+				"tls_mode":        "Terminate",
+				"hostname":        "svc.example.com",
+				"certificate_ref": "my-cert",
+			},
+		},
+	}
+
+	config, err := ParseConfig(cfg)
+	require.NoError(t, err)
+	require.Len(t, config.Listeners, 2)
+
+	assert.Equal(t, "linkkeys-tls", config.Listeners[0].Name)
+	assert.Equal(t, "TLS", config.Listeners[0].Protocol)
+	assert.Equal(t, uint64(4987), config.Listeners[0].Port)
+	assert.Nil(t, config.Listeners[0].TLSMode)
+	assert.Equal(t, "Passthrough", config.Listeners[0].EffectiveTLSMode())
+
+	assert.Equal(t, uint64(8888), config.Listeners[1].Port)
+	require.NotNil(t, config.Listeners[1].TLSMode)
+	assert.Equal(t, "Terminate", *config.Listeners[1].TLSMode)
+	require.NotNil(t, config.Listeners[1].Hostname)
+	assert.Equal(t, "svc.example.com", *config.Listeners[1].Hostname)
+	require.NotNil(t, config.Listeners[1].CertificateRef)
+	assert.Equal(t, "my-cert", *config.Listeners[1].CertificateRef)
+
+	require.NoError(t, config.ValidateListeners())
+}
+
+func TestValidateListeners(t *testing.T) {
+	tests := []struct {
+		name      string
+		listeners []ContourListener
+		wantErr   string
+	}{
+		{
+			name:      "valid TLS passthrough",
+			listeners: []ContourListener{{Name: "a", Protocol: "TLS", Port: 4987}},
+		},
+		{
+			name:      "valid TCP",
+			listeners: []ContourListener{{Name: "a", Protocol: "TCP", Port: 6000}},
+		},
+		{
+			name:      "missing name",
+			listeners: []ContourListener{{Protocol: "TCP", Port: 6000}},
+			wantErr:   "name is required",
+		},
+		{
+			name:      "bad protocol",
+			listeners: []ContourListener{{Name: "a", Protocol: "UDP", Port: 6000}},
+			wantErr:   "protocol must be",
+		},
+		{
+			name:      "port out of range",
+			listeners: []ContourListener{{Name: "a", Protocol: "TCP", Port: 70000}},
+			wantErr:   "out of range",
+		},
+		{
+			name:      "reserved port 443",
+			listeners: []ContourListener{{Name: "a", Protocol: "TLS", Port: 443}},
+			wantErr:   "already in use",
+		},
+		{
+			name: "duplicate name",
+			listeners: []ContourListener{
+				{Name: "a", Protocol: "TCP", Port: 6000},
+				{Name: "a", Protocol: "TCP", Port: 6001},
+			},
+			wantErr: "duplicate name",
+		},
+		{
+			name: "duplicate port",
+			listeners: []ContourListener{
+				{Name: "a", Protocol: "TCP", Port: 6000},
+				{Name: "b", Protocol: "TCP", Port: 6000},
+			},
+			wantErr: "already in use",
+		},
+		{
+			name:      "terminate without cert",
+			listeners: []ContourListener{{Name: "a", Protocol: "TLS", Port: 4987, TLSMode: strPtr("Terminate")}},
+			wantErr:   "certificate_ref is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{Listeners: tt.listeners}
+			err := cfg.ValidateListeners()
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}

--- a/v1/internal/gateway/reconcile.go
+++ b/v1/internal/gateway/reconcile.go
@@ -1,0 +1,556 @@
+// Package gateway implements a route-driven reconciler that opens L4
+// (TCP/TLS) listeners on the shared Contour Gateway based on TLSRoute and
+// TCPRoute resources. Apps declare intent purely in their own chart by
+// creating a route whose parentRef targets the Contour Gateway with a port;
+// this reconciler programs the matching Gateway listener, the Envoy service
+// port (exposed on the cluster VIP via the existing externalIPs), and the
+// Envoy NetworkPolicy ingress so traffic actually flows.
+//
+// It owns only the entries it creates: Gateway listeners and Envoy service
+// ports are named with the "gw-" prefix, and NetworkPolicy ports it manages
+// are tracked via an annotation. The built-in HTTP/HTTPS listeners and any
+// operator-pinned static listeners are never touched.
+package gateway
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/catalystcommunity/foundry/v1/internal/component/contour"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	// managedPrefix marks Gateway listeners and Envoy service ports created by
+	// this reconciler so it can prune its own entries without disturbing the
+	// built-in or operator-pinned ones.
+	managedPrefix = "gw-"
+
+	// managedPortsAnnotation records, on the Envoy NetworkPolicy, the set of
+	// target ports this reconciler manages (NetworkPolicy ports are unnamed, so
+	// ownership is tracked here instead of by name).
+	managedPortsAnnotation = "gateway.foundry.dev/managed-target-ports"
+
+	protocolTLS = "TLS"
+	protocolTCP = "TCP"
+
+	// envoyHTTPTargetPort is the Envoy container port for the built-in HTTP
+	// listener (80 + 8000). Used to locate the chart's main ingress rule.
+	envoyHTTPTargetPort = 8080
+)
+
+var (
+	gatewayGVR  = schema.GroupVersionResource{Group: "gateway.networking.k8s.io", Version: "v1", Resource: "gateways"}
+	tlsRouteGVR = schema.GroupVersionResource{Group: "gateway.networking.k8s.io", Version: "v1alpha2", Resource: "tlsroutes"}
+	tcpRouteGVR = schema.GroupVersionResource{Group: "gateway.networking.k8s.io", Version: "v1alpha2", Resource: "tcproutes"}
+)
+
+// Options configures which resources the reconciler manages.
+type Options struct {
+	GatewayName      string
+	GatewayNamespace string
+	EnvoyService     string
+	NetworkPolicy    string
+}
+
+// DefaultOptions returns the options matching a Foundry-installed Contour.
+func DefaultOptions() Options {
+	return Options{
+		GatewayName:      "contour",
+		GatewayNamespace: "projectcontour",
+		EnvoyService:     "contour-envoy",
+		NetworkPolicy:    "contour-envoy",
+	}
+}
+
+// DesiredListener is a single L4 listener derived from the routes.
+type DesiredListener struct {
+	Port     int32
+	Protocol string // TLS (Passthrough) or TCP
+}
+
+// Result reports what a reconcile pass found and changed.
+type Result struct {
+	Desired              []DesiredListener
+	Conflicts            []string
+	GatewayUpdated       bool
+	ServiceUpdated       bool
+	NetworkPolicyUpdated bool
+}
+
+// Changed reports whether the pass modified any cluster resource.
+func (r *Result) Changed() bool {
+	return r.GatewayUpdated || r.ServiceUpdated || r.NetworkPolicyUpdated
+}
+
+// routeCandidate is a single (port, protocol) request extracted from a route.
+type routeCandidate struct {
+	Port     int32
+	Protocol string
+	Source   string // namespace/name, for diagnostics
+}
+
+// Reconcile performs a single reconcile pass: it reads the routes targeting the
+// Gateway and converges the Gateway listeners, Envoy service ports, and Envoy
+// NetworkPolicy ingress to match.
+func Reconcile(ctx context.Context, dyn dynamic.Interface, kube kubernetes.Interface, opts Options) (*Result, error) {
+	candidates, err := collectCandidates(ctx, dyn, opts)
+	if err != nil {
+		return nil, err
+	}
+	desired, conflicts := computeDesired(candidates)
+
+	result := &Result{Desired: desired, Conflicts: conflicts}
+
+	if result.GatewayUpdated, err = reconcileGateway(ctx, dyn, opts, desired); err != nil {
+		return nil, fmt.Errorf("reconcile gateway: %w", err)
+	}
+	if result.ServiceUpdated, err = reconcileService(ctx, kube, opts, desired); err != nil {
+		return nil, fmt.Errorf("reconcile envoy service: %w", err)
+	}
+	if result.NetworkPolicyUpdated, err = reconcileNetworkPolicy(ctx, kube, opts, desired); err != nil {
+		return nil, fmt.Errorf("reconcile network policy: %w", err)
+	}
+	return result, nil
+}
+
+func listenerName(d DesiredListener) string {
+	return fmt.Sprintf("%s%s-%d", managedPrefix, strings.ToLower(d.Protocol), d.Port)
+}
+
+func routeKind(protocol string) string {
+	if protocol == protocolTLS {
+		return "TLSRoute"
+	}
+	return "TCPRoute"
+}
+
+// targetPort returns the Envoy container port for a listener port (the +8000
+// Contour remap), shared with the static-listener config path.
+func targetPort(port int32) int32 {
+	return int32(contour.EnvoyContainerPort(uint64(port)))
+}
+
+// TargetPortFor exposes the listener-port → Envoy-port remap for callers that
+// want to report where a listener lands (e.g. the controller command).
+func TargetPortFor(port int32) int32 {
+	return targetPort(port)
+}
+
+// collectCandidates lists TLSRoutes and TCPRoutes cluster-wide and extracts the
+// (port, protocol) each one requests of the target Gateway.
+func collectCandidates(ctx context.Context, dyn dynamic.Interface, opts Options) ([]routeCandidate, error) {
+	sources := []struct {
+		gvr      schema.GroupVersionResource
+		protocol string
+	}{
+		{tlsRouteGVR, protocolTLS},
+		{tcpRouteGVR, protocolTCP},
+	}
+
+	var candidates []routeCandidate
+	for _, s := range sources {
+		list, err := dyn.Resource(s.gvr).Namespace(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			// A missing route CRD just means no such routes exist yet.
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			return nil, fmt.Errorf("list %s: %w", s.gvr.Resource, err)
+		}
+		for i := range list.Items {
+			candidates = append(candidates, extractCandidates(&list.Items[i], s.protocol, opts)...)
+		}
+	}
+	return candidates, nil
+}
+
+// extractCandidates pulls the parentRefs that target the Gateway and returns a
+// candidate per ref that specifies a port.
+func extractCandidates(route *unstructured.Unstructured, protocol string, opts Options) []routeCandidate {
+	routeNS := route.GetNamespace()
+	source := routeNS + "/" + route.GetName()
+
+	parentRefs, found, err := unstructured.NestedSlice(route.Object, "spec", "parentRefs")
+	if !found || err != nil {
+		return nil
+	}
+
+	var out []routeCandidate
+	for _, raw := range parentRefs {
+		ref, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		name, _ := ref["name"].(string)
+		ns := routeNS
+		if v, ok := ref["namespace"].(string); ok && v != "" {
+			ns = v
+		}
+		if name != opts.GatewayName || ns != opts.GatewayNamespace {
+			continue
+		}
+		port, ok := toInt32(ref["port"])
+		if !ok {
+			// No port on the parentRef: the app must declare the port it wants.
+			continue
+		}
+		out = append(out, routeCandidate{Port: port, Protocol: protocol, Source: source})
+	}
+	return out
+}
+
+// computeDesired deduplicates candidates into a sorted set of listeners and
+// reports conflicts (reserved ports, or a port claimed by both TLS and TCP).
+func computeDesired(candidates []routeCandidate) ([]DesiredListener, []string) {
+	reserved := map[int32]bool{80: true, 443: true}
+	byPort := map[int32]string{}
+	conflicted := map[int32]bool{}
+	var conflicts []string
+
+	for _, c := range candidates {
+		if reserved[c.Port] {
+			conflicts = append(conflicts, fmt.Sprintf("%s: port %d is reserved for the built-in HTTP/HTTPS listener; ignoring", c.Source, c.Port))
+			continue
+		}
+		existing, seen := byPort[c.Port]
+		if !seen {
+			byPort[c.Port] = c.Protocol
+			continue
+		}
+		if existing != c.Protocol && !conflicted[c.Port] {
+			conflicted[c.Port] = true
+			conflicts = append(conflicts, fmt.Sprintf("port %d requested as both %s and %s; ignoring", c.Port, existing, c.Protocol))
+		}
+	}
+
+	desired := make([]DesiredListener, 0, len(byPort))
+	for port, protocol := range byPort {
+		if conflicted[port] {
+			continue
+		}
+		desired = append(desired, DesiredListener{Port: port, Protocol: protocol})
+	}
+	sort.Slice(desired, func(i, j int) bool { return desired[i].Port < desired[j].Port })
+	return desired, conflicts
+}
+
+func reconcileGateway(ctx context.Context, dyn dynamic.Interface, opts Options, desired []DesiredListener) (bool, error) {
+	client := dyn.Resource(gatewayGVR).Namespace(opts.GatewayNamespace)
+	gw, err := client.Get(ctx, opts.GatewayName, metav1.GetOptions{})
+	if err != nil {
+		return false, fmt.Errorf("get gateway %s/%s: %w", opts.GatewayNamespace, opts.GatewayName, err)
+	}
+
+	existing, _, err := unstructured.NestedSlice(gw.Object, "spec", "listeners")
+	if err != nil {
+		return false, fmt.Errorf("read gateway listeners: %w", err)
+	}
+	merged, changed := mergeGatewayListeners(existing, desired)
+	if !changed {
+		return false, nil
+	}
+	if err := unstructured.SetNestedSlice(gw.Object, merged, "spec", "listeners"); err != nil {
+		return false, fmt.Errorf("set gateway listeners: %w", err)
+	}
+	if _, err := client.Update(ctx, gw, metav1.UpdateOptions{}); err != nil {
+		return false, fmt.Errorf("update gateway: %w", err)
+	}
+	return true, nil
+}
+
+// mergeGatewayListeners keeps every non-managed listener untouched and replaces
+// the managed (gw-) listeners with the desired set.
+func mergeGatewayListeners(existing []interface{}, desired []DesiredListener) ([]interface{}, bool) {
+	kept := make([]interface{}, 0, len(existing))
+	for _, raw := range existing {
+		m, ok := raw.(map[string]interface{})
+		if ok {
+			if name, _ := m["name"].(string); strings.HasPrefix(name, managedPrefix) {
+				continue
+			}
+		}
+		kept = append(kept, raw)
+	}
+	for _, d := range desired {
+		kept = append(kept, gatewayListenerObject(d))
+	}
+	return kept, !reflect.DeepEqual(existing, kept)
+}
+
+// gatewayListenerObject builds an unstructured Gateway listener for a desired
+// L4 listener. TLS listeners use Passthrough mode and allow TLSRoute (SNI-based
+// routing); TCP listeners allow TCPRoute. Numbers are int64 so the value
+// round-trips through the dynamic client.
+func gatewayListenerObject(d DesiredListener) map[string]interface{} {
+	obj := map[string]interface{}{
+		"name":     listenerName(d),
+		"port":     int64(d.Port),
+		"protocol": d.Protocol,
+		"allowedRoutes": map[string]interface{}{
+			"kinds": []interface{}{
+				map[string]interface{}{"kind": routeKind(d.Protocol)},
+			},
+			"namespaces": map[string]interface{}{"from": "All"},
+		},
+	}
+	if d.Protocol == protocolTLS {
+		obj["tls"] = map[string]interface{}{"mode": "Passthrough"}
+	}
+	return obj
+}
+
+func reconcileService(ctx context.Context, kube kubernetes.Interface, opts Options, desired []DesiredListener) (bool, error) {
+	svcClient := kube.CoreV1().Services(opts.GatewayNamespace)
+	svc, err := svcClient.Get(ctx, opts.EnvoyService, metav1.GetOptions{})
+	if err != nil {
+		return false, fmt.Errorf("get service %s/%s: %w", opts.GatewayNamespace, opts.EnvoyService, err)
+	}
+
+	merged, changed := mergeServicePorts(svc.Spec.Ports, desired)
+	if !changed {
+		return false, nil
+	}
+	svc.Spec.Ports = merged
+	if _, err := svcClient.Update(ctx, svc, metav1.UpdateOptions{}); err != nil {
+		return false, fmt.Errorf("update service: %w", err)
+	}
+	return true, nil
+}
+
+// mergeServicePorts keeps every non-managed port and replaces the managed (gw-)
+// ports with one per desired listener, targeting the remapped Envoy port.
+func mergeServicePorts(existing []corev1.ServicePort, desired []DesiredListener) ([]corev1.ServicePort, bool) {
+	kept := make([]corev1.ServicePort, 0, len(existing))
+	for _, p := range existing {
+		if strings.HasPrefix(p.Name, managedPrefix) {
+			continue
+		}
+		kept = append(kept, p)
+	}
+	for _, d := range desired {
+		kept = append(kept, corev1.ServicePort{
+			Name:       listenerName(d),
+			Port:       d.Port,
+			TargetPort: intstr.FromInt32(targetPort(d.Port)),
+			Protocol:   corev1.ProtocolTCP,
+		})
+	}
+	return kept, !reflect.DeepEqual(existing, kept)
+}
+
+func reconcileNetworkPolicy(ctx context.Context, kube kubernetes.Interface, opts Options, desired []DesiredListener) (bool, error) {
+	// An empty name disables NetworkPolicy reconciliation (e.g. when the Envoy
+	// NetworkPolicy is absent or managed elsewhere).
+	if opts.NetworkPolicy == "" {
+		return false, nil
+	}
+
+	npClient := kube.NetworkingV1().NetworkPolicies(opts.GatewayNamespace)
+	np, err := npClient.Get(ctx, opts.NetworkPolicy, metav1.GetOptions{})
+	if err != nil {
+		// No NetworkPolicy means nothing is gating the traffic; that's fine.
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("get network policy %s/%s: %w", opts.GatewayNamespace, opts.NetworkPolicy, err)
+	}
+
+	prior := parsePorts(np.Annotations[managedPortsAnnotation])
+	desiredTargets := targetPortsOf(desired)
+
+	updated, changed := mergeNetworkPolicy(np.DeepCopy(), prior, desiredTargets)
+	if !changed {
+		return false, nil
+	}
+	if _, err := npClient.Update(ctx, updated, metav1.UpdateOptions{}); err != nil {
+		return false, fmt.Errorf("update network policy: %w", err)
+	}
+	return true, nil
+}
+
+// mergeNetworkPolicy ensures the ingress rule that admits Envoy traffic also
+// admits every desired target port, removes target ports it previously managed
+// that are no longer desired, and records the managed set in an annotation.
+func mergeNetworkPolicy(np *networkingv1.NetworkPolicy, prior, desired []int32) (*networkingv1.NetworkPolicy, bool) {
+	changed := false
+
+	idx := ingressRuleIndex(np.Spec.Ingress, envoyHTTPTargetPort)
+	if idx == -1 {
+		// No existing rule to extend: add a dedicated allow-from-anywhere rule.
+		if len(desired) > 0 {
+			np.Spec.Ingress = append(np.Spec.Ingress, networkingv1.NetworkPolicyIngressRule{
+				Ports: portsFor(desired),
+			})
+			changed = true
+		}
+	} else {
+		newPorts, ruleChanged := mergeRulePorts(np.Spec.Ingress[idx].Ports, prior, desired)
+		if ruleChanged {
+			np.Spec.Ingress[idx].Ports = newPorts
+			changed = true
+		}
+	}
+
+	newAnno := joinPorts(desired)
+	if np.Annotations[managedPortsAnnotation] != newAnno {
+		if np.Annotations == nil {
+			np.Annotations = map[string]string{}
+		}
+		if newAnno == "" {
+			delete(np.Annotations, managedPortsAnnotation)
+		} else {
+			np.Annotations[managedPortsAnnotation] = newAnno
+		}
+		changed = true
+	}
+	return np, changed
+}
+
+// mergeRulePorts adds desired ports not already present and removes ports that
+// were previously managed but are no longer desired, preserving every other
+// entry exactly as-is to avoid churn.
+func mergeRulePorts(existing []networkingv1.NetworkPolicyPort, prior, desired []int32) ([]networkingv1.NetworkPolicyPort, bool) {
+	desiredSet := intSet(desired)
+	removeSet := map[int32]bool{}
+	for _, p := range prior {
+		if !desiredSet[p] {
+			removeSet[p] = true
+		}
+	}
+
+	changed := false
+	result := make([]networkingv1.NetworkPolicyPort, 0, len(existing)+len(desired))
+	for _, np := range existing {
+		if v, ok := portValue(np); ok && removeSet[v] {
+			changed = true
+			continue
+		}
+		result = append(result, np)
+	}
+	for _, d := range desired {
+		if !portPresent(result, d) {
+			result = append(result, networkPolicyTCPPort(d))
+			changed = true
+		}
+	}
+	return result, changed
+}
+
+// ingressRuleIndex returns the index of the ingress rule that admits the given
+// port, or -1 if none does.
+func ingressRuleIndex(rules []networkingv1.NetworkPolicyIngressRule, port int32) int {
+	for i, rule := range rules {
+		if portPresent(rule.Ports, port) {
+			return i
+		}
+	}
+	return -1
+}
+
+func portsFor(ports []int32) []networkingv1.NetworkPolicyPort {
+	out := make([]networkingv1.NetworkPolicyPort, 0, len(ports))
+	for _, p := range ports {
+		out = append(out, networkPolicyTCPPort(p))
+	}
+	return out
+}
+
+func networkPolicyTCPPort(port int32) networkingv1.NetworkPolicyPort {
+	tcp := corev1.ProtocolTCP
+	p := intstr.FromInt32(port)
+	return networkingv1.NetworkPolicyPort{Protocol: &tcp, Port: &p}
+}
+
+func portPresent(ports []networkingv1.NetworkPolicyPort, port int32) bool {
+	for _, np := range ports {
+		if v, ok := portValue(np); ok && v == port {
+			return true
+		}
+	}
+	return false
+}
+
+func portValue(np networkingv1.NetworkPolicyPort) (int32, bool) {
+	if np.Port == nil || np.Port.Type != intstr.Int {
+		return 0, false
+	}
+	return np.Port.IntVal, true
+}
+
+// targetPortsOf returns the sorted, unique Envoy target ports for the desired
+// listeners.
+func targetPortsOf(desired []DesiredListener) []int32 {
+	seen := map[int32]bool{}
+	var out []int32
+	for _, d := range desired {
+		t := targetPort(d.Port)
+		if !seen[t] {
+			seen[t] = true
+			out = append(out, t)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out
+}
+
+func intSet(vals []int32) map[int32]bool {
+	s := make(map[int32]bool, len(vals))
+	for _, v := range vals {
+		s[v] = true
+	}
+	return s
+}
+
+func joinPorts(ports []int32) string {
+	if len(ports) == 0 {
+		return ""
+	}
+	parts := make([]string, len(ports))
+	for i, p := range ports {
+		parts[i] = strconv.Itoa(int(p))
+	}
+	return strings.Join(parts, ",")
+}
+
+func parsePorts(s string) []int32 {
+	if strings.TrimSpace(s) == "" {
+		return nil
+	}
+	var out []int32
+	for _, part := range strings.Split(s, ",") {
+		v, err := strconv.Atoi(strings.TrimSpace(part))
+		if err != nil {
+			continue
+		}
+		out = append(out, int32(v))
+	}
+	return out
+}
+
+func toInt32(v interface{}) (int32, bool) {
+	switch n := v.(type) {
+	case int64:
+		return int32(n), true
+	case int32:
+		return n, true
+	case int:
+		return int32(n), true
+	case float64:
+		return int32(n), true
+	default:
+		return 0, false
+	}
+}

--- a/v1/internal/gateway/reconcile_test.go
+++ b/v1/internal/gateway/reconcile_test.go
@@ -1,0 +1,301 @@
+package gateway
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+// --- pure helpers -----------------------------------------------------------
+
+func TestComputeDesired_DedupeSortAndConflicts(t *testing.T) {
+	candidates := []routeCandidate{
+		{Port: 6000, Protocol: protocolTCP, Source: "a/x"},
+		{Port: 4987, Protocol: protocolTLS, Source: "ns/lk"},
+		{Port: 4987, Protocol: protocolTLS, Source: "ns/lk2"}, // duplicate, same proto -> shared
+		{Port: 443, Protocol: protocolTLS, Source: "ns/bad"},  // reserved
+		{Port: 7000, Protocol: protocolTLS, Source: "ns/c"},
+		{Port: 7000, Protocol: protocolTCP, Source: "ns/d"}, // conflict -> dropped
+	}
+
+	desired, conflicts := computeDesired(candidates)
+
+	require.Len(t, desired, 2)
+	assert.Equal(t, DesiredListener{Port: 4987, Protocol: protocolTLS}, desired[0])
+	assert.Equal(t, DesiredListener{Port: 6000, Protocol: protocolTCP}, desired[1])
+
+	// reserved 443 and conflicting 7000 produce diagnostics
+	require.Len(t, conflicts, 2)
+	assert.Contains(t, conflicts[0], "443")
+	assert.Contains(t, conflicts[1], "7000")
+}
+
+func TestListenerNameAndTargetPort(t *testing.T) {
+	d := DesiredListener{Port: 4987, Protocol: protocolTLS}
+	assert.Equal(t, "gw-tls-4987", listenerName(d))
+	assert.LessOrEqual(t, len(listenerName(d)), 15, "service port names must be <=15 chars")
+	assert.Equal(t, int32(12987), targetPort(4987))
+}
+
+func TestMergeServicePorts_KeepsBaseReplacesManaged(t *testing.T) {
+	existing := []corev1.ServicePort{
+		{Name: "http", Port: 80, TargetPort: intstr.FromString("http"), Protocol: corev1.ProtocolTCP},
+		{Name: "https", Port: 443, TargetPort: intstr.FromString("https"), Protocol: corev1.ProtocolTCP},
+		{Name: "gw-tcp-9999", Port: 9999, TargetPort: intstr.FromInt32(17999), Protocol: corev1.ProtocolTCP}, // stale managed
+	}
+	desired := []DesiredListener{{Port: 4987, Protocol: protocolTLS}}
+
+	merged, changed := mergeServicePorts(existing, desired)
+	require.True(t, changed)
+
+	names := map[string]int32{}
+	for _, p := range merged {
+		names[p.Name] = p.Port
+	}
+	assert.Contains(t, names, "http")
+	assert.Contains(t, names, "https")
+	assert.NotContains(t, names, "gw-tcp-9999", "stale managed port should be pruned")
+	assert.Equal(t, int32(4987), names["gw-tls-4987"])
+
+	// idempotent on the already-merged set
+	_, changed2 := mergeServicePorts(merged, desired)
+	assert.False(t, changed2)
+}
+
+func TestMergeGatewayListeners_KeepsBaseReplacesManaged(t *testing.T) {
+	existing := []interface{}{
+		map[string]interface{}{"name": "http", "port": int64(80), "protocol": "HTTP"},
+		map[string]interface{}{"name": "gw-tls-1111", "port": int64(1111), "protocol": "TLS"}, // stale
+	}
+	desired := []DesiredListener{{Port: 4987, Protocol: protocolTLS}}
+
+	merged, changed := mergeGatewayListeners(existing, desired)
+	require.True(t, changed)
+
+	gotNames := map[string]bool{}
+	for _, raw := range merged {
+		m := raw.(map[string]interface{})
+		gotNames[m["name"].(string)] = true
+	}
+	assert.True(t, gotNames["http"])
+	assert.False(t, gotNames["gw-tls-1111"], "stale managed listener pruned")
+	assert.True(t, gotNames["gw-tls-4987"])
+
+	_, changed2 := mergeGatewayListeners(merged, desired)
+	assert.False(t, changed2)
+}
+
+func TestMergeRulePorts_AddsDesiredRemovesStaleManaged(t *testing.T) {
+	existing := []networkingv1.NetworkPolicyPort{
+		networkPolicyTCPPort(8080),
+		networkPolicyTCPPort(8443),
+		networkPolicyTCPPort(8002),
+		networkPolicyTCPPort(17999), // previously managed, now stale
+	}
+	prior := []int32{17999}
+	desired := []int32{12987}
+
+	merged, changed := mergeRulePorts(existing, prior, desired)
+	require.True(t, changed)
+
+	got := map[int32]bool{}
+	for _, p := range merged {
+		v, _ := portValue(p)
+		got[v] = true
+	}
+	assert.True(t, got[8080], "base envoy port preserved")
+	assert.True(t, got[8443])
+	assert.True(t, got[8002])
+	assert.False(t, got[17999], "stale managed target pruned")
+	assert.True(t, got[12987], "desired target added")
+}
+
+// --- integration with fake clients -----------------------------------------
+
+func newFakeDynamic() *dynamicfake.FakeDynamicClient {
+	scheme := runtime.NewScheme()
+	listKinds := map[schema.GroupVersionResource]string{
+		gatewayGVR:  "GatewayList",
+		tlsRouteGVR: "TLSRouteList",
+		tcpRouteGVR: "TCPRouteList",
+	}
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, listKinds)
+}
+
+func gatewayObject() *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "gateway.networking.k8s.io/v1",
+		"kind":       "Gateway",
+		"metadata":   map[string]interface{}{"name": "contour", "namespace": "projectcontour"},
+		"spec": map[string]interface{}{
+			"gatewayClassName": "contour",
+			"listeners": []interface{}{
+				map[string]interface{}{
+					"name": "http", "port": int64(80), "protocol": "HTTP",
+					"allowedRoutes": map[string]interface{}{"namespaces": map[string]interface{}{"from": "All"}},
+				},
+			},
+		},
+	}}
+}
+
+func routeObject(kind, apiVersion, name, ns string, port int64) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": apiVersion,
+		"kind":       kind,
+		"metadata":   map[string]interface{}{"name": name, "namespace": ns},
+		"spec": map[string]interface{}{
+			"parentRefs": []interface{}{
+				map[string]interface{}{"name": "contour", "namespace": "projectcontour", "port": port},
+			},
+		},
+	}}
+}
+
+func envoyService() *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "contour-envoy", Namespace: "projectcontour"},
+		Spec: corev1.ServiceSpec{
+			Type:        corev1.ServiceTypeClusterIP,
+			ExternalIPs: []string{"10.16.0.30"},
+			Ports: []corev1.ServicePort{
+				{Name: "http", Port: 80, TargetPort: intstr.FromString("http"), Protocol: corev1.ProtocolTCP},
+				{Name: "https", Port: 443, TargetPort: intstr.FromString("https"), Protocol: corev1.ProtocolTCP},
+			},
+		},
+	}
+}
+
+func envoyNetworkPolicy() *networkingv1.NetworkPolicy {
+	return &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "contour-envoy", Namespace: "projectcontour"},
+		Spec: networkingv1.NetworkPolicySpec{
+			Ingress: []networkingv1.NetworkPolicyIngressRule{
+				{Ports: []networkingv1.NetworkPolicyPort{
+					networkPolicyTCPPort(8080),
+					networkPolicyTCPPort(8443),
+					networkPolicyTCPPort(8002),
+				}},
+			},
+		},
+	}
+}
+
+func TestReconcile_OpensListenersFromRoutes(t *testing.T) {
+	ctx := context.Background()
+	opts := DefaultOptions()
+
+	dyn := newFakeDynamic()
+	_, err := dyn.Resource(gatewayGVR).Namespace("projectcontour").Create(ctx, gatewayObject(), metav1.CreateOptions{})
+	require.NoError(t, err)
+	_, err = dyn.Resource(tlsRouteGVR).Namespace("linkkeys").Create(ctx,
+		routeObject("TLSRoute", "gateway.networking.k8s.io/v1alpha2", "lk", "linkkeys", 4987), metav1.CreateOptions{})
+	require.NoError(t, err)
+	_, err = dyn.Resource(tcpRouteGVR).Namespace("apps").Create(ctx,
+		routeObject("TCPRoute", "gateway.networking.k8s.io/v1alpha2", "raw", "apps", 6000), metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	kube := k8sfake.NewSimpleClientset(envoyService(), envoyNetworkPolicy())
+
+	result, err := Reconcile(ctx, dyn, kube, opts)
+	require.NoError(t, err)
+	require.True(t, result.Changed())
+	require.Len(t, result.Desired, 2)
+	assert.Empty(t, result.Conflicts)
+
+	// Gateway gained both managed listeners, kept http
+	gw, err := dyn.Resource(gatewayGVR).Namespace("projectcontour").Get(ctx, "contour", metav1.GetOptions{})
+	require.NoError(t, err)
+	listeners, _, _ := unstructured.NestedSlice(gw.Object, "spec", "listeners")
+	gwNames := map[string]bool{}
+	for _, raw := range listeners {
+		gwNames[raw.(map[string]interface{})["name"].(string)] = true
+	}
+	assert.True(t, gwNames["http"])
+	assert.True(t, gwNames["gw-tls-4987"])
+	assert.True(t, gwNames["gw-tcp-6000"])
+
+	// Service gained both ports with the remapped targetPorts, kept the VIP
+	svc, err := kube.CoreV1().Services("projectcontour").Get(ctx, "contour-envoy", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"10.16.0.30"}, svc.Spec.ExternalIPs)
+	svcPorts := map[string]int32{}   // name -> port
+	svcTargets := map[string]int32{} // name -> targetPort
+	for _, p := range svc.Spec.Ports {
+		svcPorts[p.Name] = p.Port
+		svcTargets[p.Name] = p.TargetPort.IntVal
+	}
+	assert.Equal(t, int32(4987), svcPorts["gw-tls-4987"])
+	assert.Equal(t, int32(12987), svcTargets["gw-tls-4987"])
+	assert.Equal(t, int32(6000), svcPorts["gw-tcp-6000"])
+	assert.Equal(t, int32(14000), svcTargets["gw-tcp-6000"])
+
+	// NetworkPolicy admits both remapped target ports and records ownership
+	np, err := kube.NetworkingV1().NetworkPolicies("projectcontour").Get(ctx, "contour-envoy", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.True(t, portPresent(np.Spec.Ingress[0].Ports, 12987))
+	assert.True(t, portPresent(np.Spec.Ingress[0].Ports, 14000))
+	assert.True(t, portPresent(np.Spec.Ingress[0].Ports, 8080), "base port preserved")
+	assert.Equal(t, "12987,14000", np.Annotations[managedPortsAnnotation])
+
+	// Second pass is a no-op (idempotent)
+	result2, err := Reconcile(ctx, dyn, kube, opts)
+	require.NoError(t, err)
+	assert.False(t, result2.Changed(), "reconcile should be idempotent")
+}
+
+func TestReconcile_PrunesWhenRoutesRemoved(t *testing.T) {
+	ctx := context.Background()
+	opts := DefaultOptions()
+
+	// Gateway/Service/NP already carry a managed entry for port 4987 but no
+	// routes exist anymore -> the managed entry must be pruned.
+	dyn := newFakeDynamic()
+	gw := gatewayObject()
+	listeners, _, _ := unstructured.NestedSlice(gw.Object, "spec", "listeners")
+	listeners = append(listeners, gatewayListenerObject(DesiredListener{Port: 4987, Protocol: protocolTLS}))
+	_ = unstructured.SetNestedSlice(gw.Object, listeners, "spec", "listeners")
+	_, err := dyn.Resource(gatewayGVR).Namespace("projectcontour").Create(ctx, gw, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	svc := envoyService()
+	svc.Spec.Ports = append(svc.Spec.Ports, corev1.ServicePort{
+		Name: "gw-tls-4987", Port: 4987, TargetPort: intstr.FromInt32(12987), Protocol: corev1.ProtocolTCP,
+	})
+	np := envoyNetworkPolicy()
+	np.Spec.Ingress[0].Ports = append(np.Spec.Ingress[0].Ports, networkPolicyTCPPort(12987))
+	np.Annotations = map[string]string{managedPortsAnnotation: "12987"}
+	kube := k8sfake.NewSimpleClientset(svc, np)
+
+	result, err := Reconcile(ctx, dyn, kube, opts)
+	require.NoError(t, err)
+	require.True(t, result.Changed())
+	assert.Empty(t, result.Desired)
+
+	gotGw, _ := dyn.Resource(gatewayGVR).Namespace("projectcontour").Get(ctx, "contour", metav1.GetOptions{})
+	gotListeners, _, _ := unstructured.NestedSlice(gotGw.Object, "spec", "listeners")
+	for _, raw := range gotListeners {
+		assert.NotEqual(t, "gw-tls-4987", raw.(map[string]interface{})["name"])
+	}
+
+	gotSvc, _ := kube.CoreV1().Services("projectcontour").Get(ctx, "contour-envoy", metav1.GetOptions{})
+	for _, p := range gotSvc.Spec.Ports {
+		assert.NotEqual(t, "gw-tls-4987", p.Name)
+	}
+
+	gotNp, _ := kube.NetworkingV1().NetworkPolicies("projectcontour").Get(ctx, "contour-envoy", metav1.GetOptions{})
+	assert.False(t, portPresent(gotNp.Spec.Ingress[0].Ports, 12987), "pruned target removed from netpol")
+	assert.True(t, portPresent(gotNp.Spec.Ingress[0].Ports, 8080))
+	assert.Empty(t, gotNp.Annotations[managedPortsAnnotation])
+}

--- a/v1/internal/k8s/client.go
+++ b/v1/internal/k8s/client.go
@@ -31,6 +31,32 @@ type SecretResolver interface {
 	ResolveSecret(ctx context.Context, path, key string) (string, error)
 }
 
+// NewClientInCluster creates a Kubernetes client from the in-cluster service
+// account configuration. Use this when foundry runs as a pod (for example, the
+// gateway controller Deployment), where there is no kubeconfig file.
+func NewClientInCluster() (*Client, error) {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to build in-cluster config: %w", err)
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create kubernetes clientset: %w", err)
+	}
+
+	dynamicClient, err := dynamic.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create dynamic client: %w", err)
+	}
+
+	return &Client{
+		clientset:     clientset,
+		dynamicClient: dynamicClient,
+		config:        config,
+	}, nil
+}
+
 // NewClientFromKubeconfig creates a Kubernetes client from kubeconfig bytes
 func NewClientFromKubeconfig(kubeconfig []byte) (*Client, error) {
 	if len(kubeconfig) == 0 {


### PR DESCRIPTION
Without the controller, one has to create the listeners on Contour directly and then use them from a TCPRoute or TLSRoute. The controller just adds the listeners on the fly so I don't have extra operations to do.