### PR TITLE
fix: be more forgiving about tlsroute refs

### DIFF
--- a/docs/gateway-controller.md
+++ b/docs/gateway-controller.md
@@ -27,7 +27,9 @@ routes themselves, so an app team only writes a route.
 ## The model
 
 An app declares intent with a `TLSRoute` or `TCPRoute` whose `parentRefs` target
-the Contour Gateway **with a port**:
+the Contour Gateway. The listener port can be declared just once, on the
+`backendRefs` (the natural place — it's the Service port); `parentRefs[].port` is
+optional and **overrides** the backend port when set:
 
 ```yaml
 apiVersion: gateway.networking.k8s.io/v1alpha2
@@ -39,17 +41,18 @@ spec:
   parentRefs:
     - name: contour
       namespace: projectcontour
-      port: 4987            # the port the controller opens
+      # port: 4987          # optional — overrides the backend port when present
   hostnames:
     - linkkeys.example.com  # routed by SNI (TLS passthrough)
   rules:
     - backendRefs:
         - name: linkkeys
-          port: 4987
+          port: 4987        # the port the controller opens
 ```
 
-The controller reads the `port` from `parentRefs` and the protocol from the route
-kind:
+The controller derives the listener `port` from `parentRefs[].port` when set,
+otherwise from the route's `rules[].backendRefs[].port`; the protocol comes from
+the route kind:
 
 | Route kind | Listener protocol | Routing |
 | --- | --- | --- |
@@ -79,7 +82,11 @@ touched. Deleting a route prunes its port. Because it reconciles continuously, i
 also re-applies itself after a `foundry stack install`/upgrade resets the Service.
 
 Ports **80** and **443** are reserved for the built-in listeners and are refused.
-A port requested as both TLS and TCP is skipped with a logged conflict.
+A port requested as both TLS and TCP is skipped with a logged conflict. A route
+that targets the Gateway but yields no listener port — neither a `parentRefs[].port`
+nor a single `backendRefs[].port` (none set, or backends declaring different
+ports) — is skipped and named in the resync log so it's clear what was ignored
+and why, instead of vanishing silently.
 
 ## Running it
 

--- a/v1/cmd/foundry/commands/gateway/commands.go
+++ b/v1/cmd/foundry/commands/gateway/commands.go
@@ -30,7 +30,8 @@ var ControllerCommand = &cli.Command{
 	Usage: "Open Gateway listeners on the VIP from TLSRoute/TCPRoute resources",
 	Description: "Watches TLSRoute and TCPRoute resources that target the Contour Gateway and " +
 		"opens the matching L4 listener, Envoy service port (on the cluster VIP), and Envoy " +
-		"NetworkPolicy ingress. Apps declare a route with a parentRef port in their own chart; " +
+		"NetworkPolicy ingress. Apps declare a route in their own chart with the listener port on " +
+		"either the parentRef or the backendRefs; " +
 		"this controller handles the data-plane plumbing. Listeners it creates are named with a " +
 		"'gw-' prefix and pruned when their routes are removed; the built-in HTTP/HTTPS and any " +
 		"operator-pinned static listeners are left untouched.",
@@ -137,6 +138,9 @@ func clientFromFile(path string) (*k8s.Client, error) {
 func reportResult(result *gateway.Result) {
 	for _, conflict := range result.Conflicts {
 		fmt.Printf("  ⚠ %s\n", conflict)
+	}
+	for _, skip := range result.Skipped {
+		fmt.Printf("  ⚠ %s\n", skip)
 	}
 	if result.Changed() {
 		fmt.Printf("  ✓ reconciled (gateway=%t service=%t networkpolicy=%t)\n",

--- a/v1/internal/gateway/reconcile.go
+++ b/v1/internal/gateway/reconcile.go
@@ -1,8 +1,9 @@
 // Package gateway implements a route-driven reconciler that opens L4
 // (TCP/TLS) listeners on the shared Contour Gateway based on TLSRoute and
 // TCPRoute resources. Apps declare intent purely in their own chart by
-// creating a route whose parentRef targets the Contour Gateway with a port;
-// this reconciler programs the matching Gateway listener, the Envoy service
+// creating a route whose parentRef targets the Contour Gateway; the listener
+// port comes from the parentRef's port or, when that is omitted, the route's
+// backendRefs port. This reconciler programs the matching Gateway listener, the Envoy service
 // port (exposed on the cluster VIP via the existing externalIPs), and the
 // Envoy NetworkPolicy ingress so traffic actually flows.
 //
@@ -85,6 +86,7 @@ type DesiredListener struct {
 type Result struct {
 	Desired              []DesiredListener
 	Conflicts            []string
+	Skipped              []string // routes seen targeting the Gateway but ignored, with the reason
 	GatewayUpdated       bool
 	ServiceUpdated       bool
 	NetworkPolicyUpdated bool
@@ -106,13 +108,13 @@ type routeCandidate struct {
 // Gateway and converges the Gateway listeners, Envoy service ports, and Envoy
 // NetworkPolicy ingress to match.
 func Reconcile(ctx context.Context, dyn dynamic.Interface, kube kubernetes.Interface, opts Options) (*Result, error) {
-	candidates, err := collectCandidates(ctx, dyn, opts)
+	candidates, skipped, err := collectCandidates(ctx, dyn, opts)
 	if err != nil {
 		return nil, err
 	}
 	desired, conflicts := computeDesired(candidates)
 
-	result := &Result{Desired: desired, Conflicts: conflicts}
+	result := &Result{Desired: desired, Conflicts: conflicts, Skipped: skipped}
 
 	if result.GatewayUpdated, err = reconcileGateway(ctx, dyn, opts, desired); err != nil {
 		return nil, fmt.Errorf("reconcile gateway: %w", err)
@@ -150,8 +152,10 @@ func TargetPortFor(port int32) int32 {
 }
 
 // collectCandidates lists TLSRoutes and TCPRoutes cluster-wide and extracts the
-// (port, protocol) each one requests of the target Gateway.
-func collectCandidates(ctx context.Context, dyn dynamic.Interface, opts Options) ([]routeCandidate, error) {
+// (port, protocol) each one requests of the target Gateway. It also returns the
+// routes that target the Gateway but yield no candidate, each with a reason, so
+// the caller can surface them instead of dropping them silently.
+func collectCandidates(ctx context.Context, dyn dynamic.Interface, opts Options) ([]routeCandidate, []string, error) {
 	sources := []struct {
 		gvr      schema.GroupVersionResource
 		protocol string
@@ -161,6 +165,7 @@ func collectCandidates(ctx context.Context, dyn dynamic.Interface, opts Options)
 	}
 
 	var candidates []routeCandidate
+	var skipped []string
 	for _, s := range sources {
 		list, err := dyn.Resource(s.gvr).Namespace(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
 		if err != nil {
@@ -168,27 +173,38 @@ func collectCandidates(ctx context.Context, dyn dynamic.Interface, opts Options)
 			if apierrors.IsNotFound(err) {
 				continue
 			}
-			return nil, fmt.Errorf("list %s: %w", s.gvr.Resource, err)
+			return nil, nil, fmt.Errorf("list %s: %w", s.gvr.Resource, err)
 		}
 		for i := range list.Items {
-			candidates = append(candidates, extractCandidates(&list.Items[i], s.protocol, opts)...)
+			c, skip := extractCandidates(&list.Items[i], s.protocol, opts)
+			candidates = append(candidates, c...)
+			skipped = append(skipped, skip...)
 		}
 	}
-	return candidates, nil
+	return candidates, skipped, nil
 }
 
 // extractCandidates pulls the parentRefs that target the Gateway and returns a
-// candidate per ref that specifies a port.
-func extractCandidates(route *unstructured.Unstructured, protocol string, opts Options) []routeCandidate {
+// candidate per ref. The listener port comes from the parentRef's own `port`
+// when set; otherwise it falls back to the route's backend service port, which
+// for these L4 passthrough routes equals the desired listener port (so apps can
+// declare it once, on the backendRef). A parentRef that targets the Gateway but
+// yields no port is reported in the second return value rather than dropped.
+func extractCandidates(route *unstructured.Unstructured, protocol string, opts Options) ([]routeCandidate, []string) {
 	routeNS := route.GetNamespace()
 	source := routeNS + "/" + route.GetName()
 
 	parentRefs, found, err := unstructured.NestedSlice(route.Object, "spec", "parentRefs")
 	if !found || err != nil {
-		return nil
+		return nil, nil
 	}
 
+	// Derive the backend port once; it backs every parentRef on this route that
+	// omits an explicit port.
+	fallback, fallbackOK, fallbackReason := backendFallbackPort(route)
+
 	var out []routeCandidate
+	var skipped []string
 	for _, raw := range parentRefs {
 		ref, ok := raw.(map[string]interface{})
 		if !ok {
@@ -204,12 +220,67 @@ func extractCandidates(route *unstructured.Unstructured, protocol string, opts O
 		}
 		port, ok := toInt32(ref["port"])
 		if !ok {
-			// No port on the parentRef: the app must declare the port it wants.
-			continue
+			// No explicit parentRef port: fall back to the backend service port.
+			if !fallbackOK {
+				skipped = append(skipped, fmt.Sprintf(
+					"%s: targets Gateway %s/%s but no listener port could be derived (%s)",
+					source, opts.GatewayNamespace, opts.GatewayName, fallbackReason))
+				continue
+			}
+			port = fallback
 		}
 		out = append(out, routeCandidate{Port: port, Protocol: protocol, Source: source})
 	}
-	return out
+	return out, skipped
+}
+
+// backendFallbackPort derives a listener port from a route's backend service
+// ports. For the L4 passthrough routes this controller handles, the backend
+// port equals the desired listener port, so an app can declare the port once on
+// its `rules[].backendRefs[].port` and leave it off the parentRef. It returns
+// the single distinct backend port, or ok=false with a reason when none is set
+// or the backends disagree on the port (ambiguous — refuse to guess).
+func backendFallbackPort(route *unstructured.Unstructured) (int32, bool, string) {
+	rules, found, err := unstructured.NestedSlice(route.Object, "spec", "rules")
+	if !found || err != nil {
+		return 0, false, "no backendRefs port set"
+	}
+
+	seen := map[int32]bool{}
+	var first int32
+	for _, rawRule := range rules {
+		rule, ok := rawRule.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		backendRefs, ok := rule["backendRefs"].([]interface{})
+		if !ok {
+			continue
+		}
+		for _, rawRef := range backendRefs {
+			ref, ok := rawRef.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			port, ok := toInt32(ref["port"])
+			if !ok {
+				continue
+			}
+			if len(seen) == 0 {
+				first = port
+			}
+			seen[port] = true
+		}
+	}
+
+	switch len(seen) {
+	case 0:
+		return 0, false, "no backendRefs port set"
+	case 1:
+		return first, true, ""
+	default:
+		return 0, false, "backendRefs declare multiple distinct ports"
+	}
 }
 
 // computeDesired deduplicates candidates into a sorted set of listeners and

--- a/v1/internal/gateway/reconcile_test.go
+++ b/v1/internal/gateway/reconcile_test.go
@@ -41,6 +41,86 @@ func TestComputeDesired_DedupeSortAndConflicts(t *testing.T) {
 	assert.Contains(t, conflicts[1], "7000")
 }
 
+func TestExtractCandidates_PortDerivation(t *testing.T) {
+	opts := DefaultOptions()
+	const api = "gateway.networking.k8s.io/v1alpha2"
+
+	t.Run("parentRef port only is unchanged", func(t *testing.T) {
+		route := routeWithRefs("TLSRoute", api, "lk", "linkkeys", 4987, 0)
+		got, skipped := extractCandidates(route, protocolTLS, opts)
+		require.Len(t, got, 1)
+		assert.Equal(t, int32(4987), got[0].Port)
+		assert.Empty(t, skipped)
+	})
+
+	t.Run("backendRef port fallback when parentRef omits port", func(t *testing.T) {
+		route := routeWithRefs("TLSRoute", api, "lk", "linkkeys", 0, 4987)
+		got, skipped := extractCandidates(route, protocolTLS, opts)
+		require.Len(t, got, 1)
+		assert.Equal(t, int32(4987), got[0].Port)
+		assert.Empty(t, skipped)
+	})
+
+	t.Run("parentRef port wins over backendRef port", func(t *testing.T) {
+		route := routeWithRefs("TLSRoute", api, "lk", "linkkeys", 4987, 5000)
+		got, skipped := extractCandidates(route, protocolTLS, opts)
+		require.Len(t, got, 1)
+		assert.Equal(t, int32(4987), got[0].Port)
+		assert.Empty(t, skipped)
+	})
+
+	t.Run("no derivable port is skipped with a reason", func(t *testing.T) {
+		route := routeWithRefs("TLSRoute", api, "lk", "linkkeys", 0, 0)
+		got, skipped := extractCandidates(route, protocolTLS, opts)
+		assert.Empty(t, got)
+		require.Len(t, skipped, 1)
+		assert.Contains(t, skipped[0], "linkkeys/lk")
+		assert.Contains(t, skipped[0], "no listener port could be derived")
+	})
+
+	t.Run("conflicting backendRef ports are ambiguous and skipped", func(t *testing.T) {
+		route := &unstructured.Unstructured{Object: map[string]interface{}{
+			"apiVersion": api, "kind": "TLSRoute",
+			"metadata": map[string]interface{}{"name": "lk", "namespace": "linkkeys"},
+			"spec": map[string]interface{}{
+				"parentRefs": []interface{}{
+					map[string]interface{}{"name": "contour", "namespace": "projectcontour"},
+				},
+				"rules": []interface{}{
+					map[string]interface{}{"backendRefs": []interface{}{
+						map[string]interface{}{"name": "a", "port": int64(4987)},
+						map[string]interface{}{"name": "b", "port": int64(5000)},
+					}},
+				},
+			},
+		}}
+		got, skipped := extractCandidates(route, protocolTLS, opts)
+		assert.Empty(t, got)
+		require.Len(t, skipped, 1)
+		assert.Contains(t, skipped[0], "multiple distinct ports")
+	})
+
+	t.Run("route for a different gateway is ignored without a skip", func(t *testing.T) {
+		route := &unstructured.Unstructured{Object: map[string]interface{}{
+			"apiVersion": api, "kind": "TLSRoute",
+			"metadata": map[string]interface{}{"name": "other", "namespace": "x"},
+			"spec": map[string]interface{}{
+				"parentRefs": []interface{}{
+					map[string]interface{}{"name": "someone-else", "namespace": "projectcontour"},
+				},
+				"rules": []interface{}{
+					map[string]interface{}{"backendRefs": []interface{}{
+						map[string]interface{}{"name": "a"}, // no port
+					}},
+				},
+			},
+		}}
+		got, skipped := extractCandidates(route, protocolTLS, opts)
+		assert.Empty(t, got)
+		assert.Empty(t, skipped, "non-managed gateways must not produce skip diagnostics")
+	})
+}
+
 func TestListenerNameAndTargetPort(t *testing.T) {
 	d := DesiredListener{Port: 4987, Protocol: protocolTLS}
 	assert.Equal(t, "gw-tls-4987", listenerName(d))
@@ -163,6 +243,33 @@ func routeObject(kind, apiVersion, name, ns string, port int64) *unstructured.Un
 	}}
 }
 
+// routeWithRefs builds a route with a fully-specified parentRef (port=parentPort,
+// or omitted when parentPort<=0) and a single backendRef (port=backendPort, or
+// omitted when backendPort<=0).
+func routeWithRefs(kind, apiVersion, name, ns string, parentPort, backendPort int64) *unstructured.Unstructured {
+	parentRef := map[string]interface{}{"name": "contour", "namespace": "projectcontour"}
+	if parentPort > 0 {
+		parentRef["port"] = parentPort
+	}
+	backendRef := map[string]interface{}{"name": name}
+	if backendPort > 0 {
+		backendRef["port"] = backendPort
+	}
+	return &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": apiVersion,
+		"kind":       kind,
+		"metadata":   map[string]interface{}{"name": name, "namespace": ns},
+		"spec": map[string]interface{}{
+			"parentRefs": []interface{}{parentRef},
+			"rules": []interface{}{
+				map[string]interface{}{
+					"backendRefs": []interface{}{backendRef},
+				},
+			},
+		},
+	}}
+}
+
 func envoyService() *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{Name: "contour-envoy", Namespace: "projectcontour"},
@@ -253,6 +360,79 @@ func TestReconcile_OpensListenersFromRoutes(t *testing.T) {
 	result2, err := Reconcile(ctx, dyn, kube, opts)
 	require.NoError(t, err)
 	assert.False(t, result2.Changed(), "reconcile should be idempotent")
+}
+
+func TestReconcile_OpensListenerFromBackendRefPort(t *testing.T) {
+	ctx := context.Background()
+	opts := DefaultOptions()
+	const api = "gateway.networking.k8s.io/v1alpha2"
+
+	dyn := newFakeDynamic()
+	_, err := dyn.Resource(gatewayGVR).Namespace("projectcontour").Create(ctx, gatewayObject(), metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	// Two TLSRoutes for distinct SNIs, both deriving 4987 from backendRefs (no
+	// parentRef port) -> one shared gw-tls-4987 listener.
+	_, err = dyn.Resource(tlsRouteGVR).Namespace("linkkeys").Create(ctx,
+		routeWithRefs("TLSRoute", api, "lk-squizzlezig", "linkkeys", 0, 4987), metav1.CreateOptions{})
+	require.NoError(t, err)
+	_, err = dyn.Resource(tlsRouteGVR).Namespace("linkkeys").Create(ctx,
+		routeWithRefs("TLSRoute", api, "lk-todandlorna", "linkkeys", 0, 4987), metav1.CreateOptions{})
+	require.NoError(t, err)
+	// A TCPRoute deriving its port from the backendRef too.
+	_, err = dyn.Resource(tcpRouteGVR).Namespace("apps").Create(ctx,
+		routeWithRefs("TCPRoute", api, "raw", "apps", 0, 6000), metav1.CreateOptions{})
+	require.NoError(t, err)
+	// A route targeting the gateway with no derivable port -> skipped + reported.
+	_, err = dyn.Resource(tlsRouteGVR).Namespace("apps").Create(ctx,
+		routeWithRefs("TLSRoute", api, "noport", "apps", 0, 0), metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	kube := k8sfake.NewSimpleClientset(envoyService(), envoyNetworkPolicy())
+
+	result, err := Reconcile(ctx, dyn, kube, opts)
+	require.NoError(t, err)
+	require.True(t, result.Changed())
+	assert.Empty(t, result.Conflicts)
+
+	require.Len(t, result.Desired, 2)
+	assert.Equal(t, DesiredListener{Port: 4987, Protocol: protocolTLS}, result.Desired[0])
+	assert.Equal(t, DesiredListener{Port: 6000, Protocol: protocolTCP}, result.Desired[1])
+
+	require.Len(t, result.Skipped, 1)
+	assert.Contains(t, result.Skipped[0], "apps/noport")
+
+	gw, err := dyn.Resource(gatewayGVR).Namespace("projectcontour").Get(ctx, "contour", metav1.GetOptions{})
+	require.NoError(t, err)
+	listeners, _, _ := unstructured.NestedSlice(gw.Object, "spec", "listeners")
+	gwNames := map[string]bool{}
+	for _, raw := range listeners {
+		gwNames[raw.(map[string]interface{})["name"].(string)] = true
+	}
+	assert.True(t, gwNames["gw-tls-4987"], "shared TLS listener derived from backendRefs")
+	assert.True(t, gwNames["gw-tcp-6000"])
+}
+
+func TestReconcile_ReservedBackendPortRefused(t *testing.T) {
+	ctx := context.Background()
+	opts := DefaultOptions()
+	const api = "gateway.networking.k8s.io/v1alpha2"
+
+	dyn := newFakeDynamic()
+	_, err := dyn.Resource(gatewayGVR).Namespace("projectcontour").Create(ctx, gatewayObject(), metav1.CreateOptions{})
+	require.NoError(t, err)
+	// A reserved port (443) derived from the backendRef is still refused.
+	_, err = dyn.Resource(tlsRouteGVR).Namespace("apps").Create(ctx,
+		routeWithRefs("TLSRoute", api, "https", "apps", 0, 443), metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	kube := k8sfake.NewSimpleClientset(envoyService(), envoyNetworkPolicy())
+
+	result, err := Reconcile(ctx, dyn, kube, opts)
+	require.NoError(t, err)
+	assert.Empty(t, result.Desired)
+	require.Len(t, result.Conflicts, 1)
+	assert.Contains(t, result.Conflicts[0], "443")
 }
 
 func TestReconcile_PrunesWhenRoutesRemoved(t *testing.T) {


### PR DESCRIPTION
This just allows things to be more forgiving if you don't have a parentRef or something as long as there's not going to be a conflict.