### PR TITLE
test: fix env-dependent TestStatusCommand panic

### DIFF
--- a/v1/cmd/foundry/commands/component/status_test.go
+++ b/v1/cmd/foundry/commands/component/status_test.go
@@ -15,6 +15,13 @@ import (
 )
 
 func TestStatusCommand(t *testing.T) {
+	// Isolate config discovery from the developer's real ~/.foundry directory.
+	// FindConfig falls back to $FOUNDRY_CONFIG_DIR/stack.yaml; pointing it at an
+	// empty temp dir makes the "no config" cases deterministically return the
+	// expected "failed to find config" error instead of picking up a real
+	// stack.yaml and panicking downstream.
+	t.Setenv("FOUNDRY_CONFIG_DIR", t.TempDir())
+
 	// Create a fresh registry for testing
 	testRegistry := component.NewRegistry()
 


### PR DESCRIPTION
## What

`TestStatusCommand`'s "no config" cases assume `FindConfig` returns an error when no config file exists. On any machine with a real `~/.foundry/stack.yaml`, `FindConfig` instead *succeeds*, execution falls into `CheckOpenBAOStatus` with a partial config, and nil-derefs (SIGSEGV). It passes on clean CI (no `~/.foundry`), so it went unnoticed.

Fix: point `FOUNDRY_CONFIG_DIR` at an empty `t.TempDir()` so config discovery is isolated from `$HOME`. The case then deterministically hits the expected `"failed to find config"` error. Passes on both clean CI and developer machines.

One file, test-only, no production changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)