### PR TITLE
feat: add Tailscale component Config with validation

### DIFF
--- a/docs/tailscale-integration.md
+++ b/docs/tailscale-integration.md
@@ -55,7 +55,12 @@ Your Tailscale ACL must allow:
 
 ### Single Control Plane Setup
 
-For single control plane deployments, use a dedicated VIP address that is routable via Tailscale:
+See `validateK8sVIPUniqueness()` in v1/internal/config/types.go and "Understanding VIP Routing on Tailscale" below for details.
+
+For Tailscale deployments, use a CGNAT IP in the 100.64.0.0/10 range that:
+- Is NOT assigned to any of your cluster nodes
+- Is within your Tailscale network's IP range
+- Will be advertised as a subnet route by the Tailscale operator
 
 ```yaml
 cluster:

--- a/v1/internal/component/tailscale/types.go
+++ b/v1/internal/component/tailscale/types.go
@@ -1,0 +1,76 @@
+package tailscale
+
+import (
+	"fmt"
+)
+
+// Config is the Tailscale operator component configuration.
+//
+// Hand-written (like grafana/velero) rather than CSIL-generated: the Tailscale
+// component is not persisted through the stack config schema, so it does not
+// have a csil/v1/components/tailscale.csil source.
+//
+// OAuth credential and operator-image fields are pointers so callers can
+// distinguish "not set" (nil) from an explicit empty string; SetDefaults fills
+// in defaults only when a field is nil.
+type Config struct {
+	// OAuthClientID is the Tailscale OAuth client ID (required).
+	OAuthClientID *string `json:"oauth_client_id,omitempty" yaml:"oauth_client_id,omitempty"`
+
+	// OAuthClientSecret is the Tailscale OAuth client secret (required).
+	OAuthClientSecret *string `json:"oauth_client_secret,omitempty" yaml:"oauth_client_secret,omitempty"`
+
+	// OperatorImage overrides the Tailscale operator image
+	// (default: tailscale/operator:latest).
+	OperatorImage *string `json:"operator_image,omitempty" yaml:"operator_image,omitempty"`
+
+	// Tags are the Tailscale ACL tags applied to operator-managed devices
+	// (default: ["tag:k8s-foundry"]).
+	Tags []string `json:"tags,omitempty" yaml:"tags,omitempty"`
+
+	// AdvertiseRoutes are the subnet routes the operator advertises; the VIP
+	// route is appended during installation.
+	AdvertiseRoutes []string `json:"advertise_routes,omitempty" yaml:"advertise_routes,omitempty"`
+}
+
+// Validate checks that the Tailscale configuration is valid.
+// It ensures required OAuth credentials are provided.
+func (c *Config) Validate() error {
+	if c == nil {
+		return fmt.Errorf("config cannot be nil")
+	}
+
+	// OAuth credentials are required
+	if c.OAuthClientID == nil || *c.OAuthClientID == "" {
+		return fmt.Errorf("oauth_client_id is required")
+	}
+	if c.OAuthClientSecret == nil || *c.OAuthClientSecret == "" {
+		return fmt.Errorf("oauth_client_secret is required")
+	}
+
+	return nil
+}
+
+// SetDefaults sets default values for optional fields if not provided.
+func (c *Config) SetDefaults() {
+	if c == nil {
+		return
+	}
+
+	// Set default operator image if not specified
+	if c.OperatorImage == nil {
+		image := "tailscale/operator:latest"
+		c.OperatorImage = &image
+	}
+
+	// Set default tags if not specified
+	if c.Tags == nil {
+		c.Tags = []string{"tag:k8s-foundry"}
+	}
+
+	// Initialize advertise_routes as empty slice if nil
+	// (will be populated with VIP route during installation)
+	if c.AdvertiseRoutes == nil {
+		c.AdvertiseRoutes = []string{}
+	}
+}

--- a/v1/internal/component/tailscale/types_validation_test.go
+++ b/v1/internal/component/tailscale/types_validation_test.go
@@ -1,0 +1,207 @@
+package tailscale
+
+import (
+	"testing"
+)
+
+func TestConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  *Config
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "nil config",
+			config:  nil,
+			wantErr: true,
+			errMsg:  "config cannot be nil",
+		},
+		{
+			name: "missing oauth_client_id",
+			config: &Config{
+				OAuthClientSecret: stringPtr("secret-456"),
+			},
+			wantErr: true,
+			errMsg:  "oauth_client_id is required",
+		},
+		{
+			name: "empty oauth_client_id",
+			config: &Config{
+				OAuthClientID:     stringPtr(""),
+				OAuthClientSecret: stringPtr("secret-456"),
+			},
+			wantErr: true,
+			errMsg:  "oauth_client_id is required",
+		},
+		{
+			name: "missing oauth_client_secret",
+			config: &Config{
+				OAuthClientID: stringPtr("client-123"),
+			},
+			wantErr: true,
+			errMsg:  "oauth_client_secret is required",
+		},
+		{
+			name: "empty oauth_client_secret",
+			config: &Config{
+				OAuthClientID:     stringPtr("client-123"),
+				OAuthClientSecret: stringPtr(""),
+			},
+			wantErr: true,
+			errMsg:  "oauth_client_secret is required",
+		},
+		{
+			name: "valid minimal config",
+			config: &Config{
+				OAuthClientID:     stringPtr("client-123"),
+				OAuthClientSecret: stringPtr("secret-456"),
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid full config",
+			config: &Config{
+				OAuthClientID:     stringPtr("client-123"),
+				OAuthClientSecret: stringPtr("secret-456"),
+				OperatorImage:     stringPtr("tailscale/operator:v1.2.3"),
+				AdvertiseRoutes:   []string{"10.0.0.0/8"},
+				Tags:              []string{"tag:k8s-foundry", "tag:production"},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if err != nil && tt.errMsg != "" && err.Error() != tt.errMsg {
+				t.Errorf("Validate() error message = %q, want %q", err.Error(), tt.errMsg)
+			}
+		})
+	}
+}
+
+func TestConfig_SetDefaults(t *testing.T) {
+	tests := []struct {
+		name   string
+		config *Config
+		check  func(t *testing.T, cfg *Config)
+	}{
+		{
+			name:   "nil config does not panic",
+			config: nil,
+			check: func(t *testing.T, cfg *Config) {
+				// Should not panic
+			},
+		},
+		{
+			name: "sets default operator image",
+			config: &Config{
+				OAuthClientID:     stringPtr("client-123"),
+				OAuthClientSecret: stringPtr("secret-456"),
+			},
+			check: func(t *testing.T, cfg *Config) {
+				if cfg.OperatorImage == nil {
+					t.Error("Expected OperatorImage to be set")
+					return
+				}
+				if *cfg.OperatorImage != "tailscale/operator:latest" {
+					t.Errorf("OperatorImage = %q, want %q", *cfg.OperatorImage, "tailscale/operator:latest")
+				}
+			},
+		},
+		{
+			name: "preserves custom operator image",
+			config: &Config{
+				OAuthClientID:     stringPtr("client-123"),
+				OAuthClientSecret: stringPtr("secret-456"),
+				OperatorImage:     stringPtr("custom/operator:v1.0.0"),
+			},
+			check: func(t *testing.T, cfg *Config) {
+				if cfg.OperatorImage == nil {
+					t.Error("Expected OperatorImage to be set")
+					return
+				}
+				if *cfg.OperatorImage != "custom/operator:v1.0.0" {
+					t.Errorf("OperatorImage = %q, want %q", *cfg.OperatorImage, "custom/operator:v1.0.0")
+				}
+			},
+		},
+		{
+			name: "sets default tags",
+			config: &Config{
+				OAuthClientID:     stringPtr("client-123"),
+				OAuthClientSecret: stringPtr("secret-456"),
+			},
+			check: func(t *testing.T, cfg *Config) {
+				if cfg.Tags == nil {
+					t.Error("Expected Tags to be set")
+					return
+				}
+				if len(cfg.Tags) != 1 || cfg.Tags[0] != "tag:k8s-foundry" {
+					t.Errorf("Tags = %v, want [tag:k8s-foundry]", cfg.Tags)
+				}
+			},
+		},
+		{
+			name: "preserves custom tags",
+			config: &Config{
+				OAuthClientID:     stringPtr("client-123"),
+				OAuthClientSecret: stringPtr("secret-456"),
+				Tags:              []string{"tag:custom", "tag:production"},
+			},
+			check: func(t *testing.T, cfg *Config) {
+				if len(cfg.Tags) != 2 {
+					t.Errorf("Tags length = %d, want 2", len(cfg.Tags))
+				}
+			},
+		},
+		{
+			name: "initializes empty advertise routes",
+			config: &Config{
+				OAuthClientID:     stringPtr("client-123"),
+				OAuthClientSecret: stringPtr("secret-456"),
+			},
+			check: func(t *testing.T, cfg *Config) {
+				if cfg.AdvertiseRoutes == nil {
+					t.Error("Expected AdvertiseRoutes to be initialized")
+					return
+				}
+				if len(cfg.AdvertiseRoutes) != 0 {
+					t.Errorf("AdvertiseRoutes length = %d, want 0", len(cfg.AdvertiseRoutes))
+				}
+			},
+		},
+		{
+			name: "preserves custom advertise routes",
+			config: &Config{
+				OAuthClientID:     stringPtr("client-123"),
+				OAuthClientSecret: stringPtr("secret-456"),
+				AdvertiseRoutes:   []string{"10.0.0.0/8", "192.168.0.0/16"},
+			},
+			check: func(t *testing.T, cfg *Config) {
+				if len(cfg.AdvertiseRoutes) != 2 {
+					t.Errorf("AdvertiseRoutes length = %d, want 2", len(cfg.AdvertiseRoutes))
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := tt.config
+			cfg.SetDefaults()
+			tt.check(t, cfg)
+		})
+	}
+}
+
+// Helper function to create string pointers
+func stringPtr(s string) *string {
+	return &s
+}


### PR DESCRIPTION
Add Config struct (hand-written like grafana/velero):
- OAuthClientID, OAuthClientSecret (required)
- OperatorImage, Tags, AdvertiseRoutes (optional with defaults)
- Validate() and SetDefaults() with comprehensive tests

Docs cleanup per feedback:
- Replace ARP sentence with reference to validateK8sVIPUniqueness()
- Remove Setup Steps/Step 1 headers (self-evident)
- Remove Testing (local) block (instructions in scripts/README.md)

This is the pure Tailscale scaffolding PR - one concern per PR.