### PR TITLE
fix: combine PRs 38, 36, 37 - tailscale scaffolding, feedback cleanup…

### DIFF
--- a/docs/tailscale-integration.md
+++ b/docs/tailscale-integration.md
@@ -212,6 +212,21 @@ Before deploying:
 - [ ] `allow_cgnat_vip: true` is set in cluster config
 - [ ] Workers can reach the VIP: `curl -k https://<VIP>:6443/version`
 
+## Not Implemented (Roadmap)
+
+The following Tailscale Kubernetes Operator use cases are **not yet implemented** in Foundry:
+
+| Use Case | Status | Notes |
+|----------|--------|-------|
+| **Secure API Server Access** | Not implemented | API server proxy via Tailscale Operator |
+| **Expose Services via Ingress** | Not implemented | Tailscale IngressClass |
+| **Expose Services via Funnel** | Not implemented | Public internet exposure |
+| **Pod → Tailnet Egress** | Not implemented | Pods accessing tailnet services |
+| **Subnet Routers** | Partially implemented | Manual VIP subnet route (no operator) |
+| **Exit Nodes** | Not implemented | Cluster as exit node |
+| **Multi-Cluster Connectivity** | Not implemented | Cross-cluster service communication |
+| **High Availability (Multi-Cluster)** | Not implemented | Multi-cluster load balancing |
+
 ## Roadmap
 
 Future enhancements planned for Tailscale integration:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,40 @@
+# scripts/test-local.sh
+
+Local validation harness used to test the Tailscale integration PR stack (and
+any component work) on a developer machine before pushing.
+
+## Modes
+
+| Command | What it does | Needs |
+|---------|--------------|-------|
+| `scripts/test-local.sh` | `go build ./...`, `go vet ./...`, `gofmt -l`, and `go test -short` for every package **except** the Docker-gated `./test/integration/...`, plus hygiene checks (no conflict markers, no secret-leaking debug prints). | go |
+| `scripts/test-local.sh --kind` | The above, then spins up a throwaway [kind](https://kind.sigs.k8s.io/) cluster and server-side dry-run-applies any rendered manifests in `$MANIFEST_DIR`. | go, kind, kubectl, Docker |
+| `scripts/test-local.sh --kind --keep` | Same, but leaves the kind cluster running for manual poking. | go, kind, kubectl, Docker |
+| `scripts/test-local.sh --integration` | Runs the full suite **including** `./test/integration/...` (testcontainers), dropping `-short` and adding `-tags=integration` so those tests actually execute. | go, container runtime |
+
+The default mode matches the CI contract in `.reactorcide/jobs/test.yaml`: gofmt,
+vet, build, then `go test -short`. The integration suite is excluded three ways:
+the package list skips it, `-short` trips the `testing.Short()` guards in the
+untagged tests (`k3s`, `openbao`, `helm`, `powerdns`, `zot`), and the absence of
+`-tags=integration` hides the tagged ones (`phase3_*`, `stack_integration`)
+from the build entirely. `--integration` undoes the latter two — dropping only
+`-short`, as an earlier revision of this script did, silently skips every
+build-tagged test. See `docs/testing.md` for the same distinction.
+
+## Useful env vars
+
+- `PKG=./internal/component/tailscale/...` — narrow the test run to one package.
+- `CLUSTER_NAME=my-cluster` — name of the kind cluster (default `foundry-local-test`).
+- `MANIFEST_DIR=/path/to/rendered/yaml` — directory of manifests for `--kind` to
+  dry-run-apply against the live API server (used by the CRD/CoreDNS PRs).
+- `FOUNDRY_CONFIG_DIR=$(mktemp -d)` — isolate config discovery from your real
+  `~/.foundry` when running command tests directly.
+
+## Why kind, not k3s, for local unit validation
+
+Foundry installs against real hosts over SSH, so a full end-to-end install isn't
+what a per-PR check needs. What each PR *can* verify locally is: the code builds,
+unit tests pass, and — for PRs that generate Kubernetes manifests/CRDs — that
+those manifests are accepted by a live API server. kind gives us that live API
+server cheaply in Docker without provisioning nodes. Each PR's own "Testing"
+section says which mode to run.

--- a/scripts/test-local.sh
+++ b/scripts/test-local.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+#
+# test-local.sh — local validation harness for the Tailscale integration stack.
+#
+# Each PR in the stack documents which mode(s) it should be tested with.
+# By default this runs the fast checks (build + unit tests). Pass --kind to
+# additionally spin up a throwaway kind cluster and apply the component's
+# generated manifests/CRDs against a live API server.
+#
+# Usage:
+#   scripts/test-local.sh                # build + unit tests (default, no cluster)
+#   scripts/test-local.sh --kind         # + spin up kind and smoke-test manifests
+#   scripts/test-local.sh --kind --keep  # leave the kind cluster running afterwards
+#   scripts/test-local.sh --integration  # also run the Docker/testcontainers suite
+#   PKG=./internal/component/tailscale/... scripts/test-local.sh   # narrow tests
+#
+# By default the Docker-backed integration suite under ./test/integration/... is
+# EXCLUDED — it needs a running Docker daemon and is the slow tier. Use --kind
+# (manifest smoke test) or --integration (full container suite) to opt in.
+#
+# Requirements: go. For --kind/--integration: kind/kubectl/Docker as noted.
+set -euo pipefail
+
+CLUSTER_NAME="${CLUSTER_NAME:-foundry-local-test}"
+# Default: everything except the Docker-gated integration suite.
+PKG="${PKG:-}"
+DO_KIND=0
+DO_INTEGRATION=0
+KEEP=0
+
+for arg in "$@"; do
+  case "$arg" in
+    --kind) DO_KIND=1 ;;
+    --integration) DO_INTEGRATION=1 ;;
+    --keep) KEEP=1 ;;
+    -h|--help) grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "unknown arg: $arg" >&2; exit 2 ;;
+  esac
+done
+
+# Resolve repo root and the Go module dir (module lives under v1/).
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MODDIR="$ROOT/v1"
+
+step() { printf '\n\033[1;34m==> %s\033[0m\n' "$1"; }
+ok()   { printf '\033[1;32m✓ %s\033[0m\n' "$1"; }
+
+# Resolve the package set to test. When PKG is unset, test everything except the
+# Docker-gated integration suite (unless --integration was passed).
+TEST_PKGS=()
+if [[ -n "$PKG" ]]; then
+  TEST_PKGS=("$PKG")
+elif [[ "$DO_INTEGRATION" -eq 1 ]]; then
+  TEST_PKGS=("./...")
+else
+  while IFS= read -r pkg; do
+    TEST_PKGS+=("$pkg")
+  done < <(cd "$MODDIR" && go list ./... | grep -v '/test/integration')
+fi
+
+step "go build"
+( cd "$MODDIR" && go build ./... )
+ok "build"
+
+step "go vet"
+( cd "$MODDIR" && go vet ./... )
+ok "vet"
+
+step "gofmt check"
+if [[ -n "$(cd "$MODDIR" && gofmt -l .)" ]]; then
+  echo "unformatted files found:" >&2
+  cd "$MODDIR" && gofmt -l . >&2
+  exit 1
+fi
+ok "gofmt"
+
+# --integration drops -short AND sets -tags=integration. Both are required:
+# the untagged tests under ./test/integration/... (k3s, openbao, helm, powerdns,
+# zot) short-circuit on testing.Short(), while phase3_* and stack_integration
+# are behind a //go:build integration tag and are invisible without it. This
+# matches the tagged invocation documented in docs/testing.md.
+if [[ "$DO_INTEGRATION" -eq 1 ]]; then
+  step "go test (integration mode, -tags=integration)"
+  ( cd "$MODDIR" && go test -tags=integration "${TEST_PKGS[@]}" )
+  ok "integration tests"
+else
+  step "go test -short (fast mode)"
+  ( cd "$MODDIR" && go test -short "${TEST_PKGS[@]}" )
+  ok "unit tests"
+fi
+
+# Guard against regressions the reviews found: leftover conflict markers or
+# debug prints that leak secrets. Cheap to check, worth catching in every PR.
+step "hygiene checks (conflict markers / secret-leaking debug prints)"
+# Only the <<<<<<< / >>>>>>> pair is checked: a bare ^======= line is also a
+# legal Markdown setext heading underline, so matching it fails on valid docs.
+if git -C "$ROOT" grep -nE '^(<<<<<<<|>>>>>>>) ' -- '*.go' '*.md' >/dev/null 2>&1; then
+  echo "found merge-conflict markers:" >&2
+  git -C "$ROOT" grep -nE '^(<<<<<<<|>>>>>>>) ' -- '*.go' '*.md' >&2
+  exit 1
+fi
+if git -C "$ROOT" grep -nE 'DEBUG:.*(client_id|clientId|secret|token)' -- '*.go' >/dev/null 2>&1; then
+  echo "found debug print that may leak a secret:" >&2
+  git -C "$ROOT" grep -nE 'DEBUG:.*(client_id|clientId|secret|token)' -- '*.go' >&2
+  exit 1
+fi
+ok "hygiene"
+
+if [[ "$DO_KIND" -eq 0 ]]; then
+  echo
+  ok "all fast checks passed (run with --kind for live-cluster smoke test)"
+  exit 0
+fi
+
+# ---- kind live smoke test ---------------------------------------------------
+command -v kind >/dev/null    || { echo "kind not found on PATH" >&2; exit 1; }
+command -v kubectl >/dev/null || { echo "kubectl not found on PATH" >&2; exit 1; }
+
+cleanup() {
+  if [[ "$KEEP" -eq 1 ]]; then
+    echo "leaving cluster '$CLUSTER_NAME' running (--keep)"
+    return
+  fi
+  step "deleting kind cluster '$CLUSTER_NAME'"
+  kind delete cluster --name "$CLUSTER_NAME" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+step "creating kind cluster '$CLUSTER_NAME'"
+if ! kind get clusters 2>/dev/null | grep -qx "$CLUSTER_NAME"; then
+  kind create cluster --name "$CLUSTER_NAME" --wait 60s
+fi
+kubectl cluster-info --context "kind-$CLUSTER_NAME" >/dev/null
+ok "cluster up"
+
+# Per-PR manifest smoke test hook.
+# Later PRs that generate manifests/CRDs (helm values, Connector/DNSConfig CRDs,
+# CoreDNS ConfigMap patch) drop rendered YAML into a dir and set MANIFEST_DIR so
+# this loop dry-run-applies them against the live API server to catch schema
+# errors. If nothing is provided, this is a no-op and the cluster-up is the test.
+MANIFEST_DIR="${MANIFEST_DIR:-}"
+if [[ -n "$MANIFEST_DIR" && -d "$MANIFEST_DIR" ]]; then
+  step "server-side dry-run apply of manifests in $MANIFEST_DIR"
+  shopt -s nullglob
+  for f in "$MANIFEST_DIR"/*.yaml "$MANIFEST_DIR"/*.yml; do
+    echo "  applying $f"
+    kubectl apply --dry-run=server -f "$f" --context "kind-$CLUSTER_NAME"
+  done
+  ok "manifests validate against live API server"
+else
+  echo "no MANIFEST_DIR set — skipping manifest apply (cluster-up smoke test only)"
+fi
+
+echo
+ok "kind smoke test passed"

--- a/v1/internal/component/k3s/vip_test.go
+++ b/v1/internal/component/k3s/vip_test.go
@@ -191,16 +191,18 @@ func TestDetectNetworkInterface(t *testing.T) {
 // TestDetermineVIPConfig tests VIP configuration determination
 func TestDetermineVIPConfig(t *testing.T) {
 	tests := []struct {
-		name      string
-		vip       string
-		setupMock func() *mockSSHExecutor
-		want      *VIPConfig
-		wantErr   bool
-		errMsg    string
+		name       string
+		vip        string
+		allowCGNAT bool
+		setupMock  func() *mockSSHExecutor
+		want       *VIPConfig
+		wantErr    bool
+		errMsg     string
 	}{
 		{
-			name: "successful VIP config determination",
-			vip:  "192.168.1.100",
+			name:       "successful VIP config determination",
+			vip:        "192.168.1.100",
+			allowCGNAT: false,
 			setupMock: func() *mockSSHExecutor {
 				return &mockSSHExecutor{
 					execFunc: func(command string) (*ssh.ExecResult, error) {
@@ -214,13 +216,14 @@ func TestDetermineVIPConfig(t *testing.T) {
 			want: &VIPConfig{
 				VIP:           "192.168.1.100",
 				Interface:     "eth0",
-				AllowCGNATVIP: boolPtr(false),
+				AllowCGNATVIP: func() *bool { v := false; return &v }(),
 			},
 			wantErr: false,
 		},
 		{
-			name: "invalid VIP",
-			vip:  "not-an-ip",
+			name:       "invalid VIP",
+			vip:        "not-an-ip",
+			allowCGNAT: false,
 			setupMock: func() *mockSSHExecutor {
 				return &mockSSHExecutor{}
 			},
@@ -228,8 +231,9 @@ func TestDetermineVIPConfig(t *testing.T) {
 			errMsg:  "VIP validation failed",
 		},
 		{
-			name: "interface detection fails",
-			vip:  "192.168.1.100",
+			name:       "interface detection fails",
+			vip:        "192.168.1.100",
+			allowCGNAT: false,
 			setupMock: func() *mockSSHExecutor {
 				return &mockSSHExecutor{
 					execFunc: func(command string) (*ssh.ExecResult, error) {
@@ -240,12 +244,33 @@ func TestDetermineVIPConfig(t *testing.T) {
 			wantErr: true,
 			errMsg:  "interface detection failed",
 		},
+		{
+			name:       "successful VIP config with allowCGNAT=true",
+			vip:        "100.64.0.1",
+			allowCGNAT: true,
+			setupMock: func() *mockSSHExecutor {
+				return &mockSSHExecutor{
+					execFunc: func(command string) (*ssh.ExecResult, error) {
+						return &ssh.ExecResult{
+							Stdout:   "eth0\n",
+							ExitCode: 0,
+						}, nil
+					},
+				}
+			},
+			want: &VIPConfig{
+				VIP:           "100.64.0.1",
+				Interface:     "eth0",
+				AllowCGNATVIP: func() *bool { v := true; return &v }(),
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mock := tt.setupMock()
-			got, err := DetermineVIPConfig(tt.vip, mock, false)
+			got, err := DetermineVIPConfig(tt.vip, mock, tt.allowCGNAT)
 
 			if tt.wantErr {
 				require.Error(t, err)

--- a/v1/internal/component/tailscale/install.go
+++ b/v1/internal/component/tailscale/install.go
@@ -1,0 +1,41 @@
+package tailscale
+
+import (
+	"fmt"
+)
+
+const (
+	// DefaultNamespace is the namespace where Tailscale operator will be installed
+	DefaultNamespace = "tailscale"
+)
+
+// Installer handles Tailscale operator installation and configuration.
+type Installer struct {
+	config *Config
+	vip    string
+}
+
+// NewInstaller creates a new Tailscale installer with the given configuration.
+func NewInstaller(cfg *Config, vip string) (*Installer, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("config cannot be nil")
+	}
+
+	// Validate configuration
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid configuration: %w", err)
+	}
+
+	// Validate VIP is set
+	if vip == "" {
+		return nil, fmt.Errorf("VIP cannot be empty")
+	}
+
+	// Set defaults after validation succeeds
+	cfg.SetDefaults()
+
+	return &Installer{
+		config: cfg,
+		vip:    vip,
+	}, nil
+}

--- a/v1/internal/component/tailscale/install_test.go
+++ b/v1/internal/component/tailscale/install_test.go
@@ -1,0 +1,106 @@
+package tailscale
+
+import (
+	"testing"
+)
+
+func TestNewInstaller(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  *Config
+		vip     string
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "nil config",
+			config:  nil,
+			vip:     "100.81.89.100",
+			wantErr: true,
+			errMsg:  "config cannot be nil",
+		},
+		{
+			name: "invalid config - missing oauth_client_id",
+			config: &Config{
+				OAuthClientSecret: installerStringPtr("secret-456"),
+			},
+			vip:     "100.81.89.100",
+			wantErr: true,
+			errMsg:  "invalid configuration: oauth_client_id is required",
+		},
+		{
+			name: "valid config",
+			config: &Config{
+				OAuthClientID:     installerStringPtr("client-123"),
+				OAuthClientSecret: installerStringPtr("secret-456"),
+			},
+			vip:     "100.81.89.100",
+			wantErr: false,
+		},
+		{
+			name: "valid config with custom settings",
+			config: &Config{
+				OAuthClientID:     installerStringPtr("client-123"),
+				OAuthClientSecret: installerStringPtr("secret-456"),
+				OperatorImage:     installerStringPtr("custom/operator:v1.0.0"),
+				Tags:              []string{"tag:custom"},
+			},
+			vip:     "100.81.89.100",
+			wantErr: false,
+		},
+		{
+			name: "empty VIP",
+			config: &Config{
+				OAuthClientID:     installerStringPtr("client-123"),
+				OAuthClientSecret: installerStringPtr("secret-456"),
+			},
+			vip:     "",
+			wantErr: true,
+			errMsg:  "VIP cannot be empty",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			installer, err := NewInstaller(tt.config, tt.vip)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewInstaller() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if err != nil && tt.errMsg != "" && err.Error() != tt.errMsg {
+				t.Errorf("NewInstaller() error message = %q, want %q", err.Error(), tt.errMsg)
+				return
+			}
+			if !tt.wantErr && installer == nil {
+				t.Error("NewInstaller() returned nil installer without error")
+			}
+		})
+	}
+}
+
+func TestNewInstaller_SetsDefaults(t *testing.T) {
+	config := &Config{
+		OAuthClientID:     installerStringPtr("client-123"),
+		OAuthClientSecret: installerStringPtr("secret-456"),
+	}
+
+	installer, err := NewInstaller(config, "100.81.89.100")
+	if err != nil {
+		t.Fatalf("NewInstaller() unexpected error: %v", err)
+	}
+
+	// Verify defaults were set
+	if installer.config.OperatorImage == nil {
+		t.Error("Expected OperatorImage to be set by defaults")
+	}
+	if installer.config.Tags == nil || len(installer.config.Tags) == 0 {
+		t.Error("Expected Tags to be set by defaults")
+	}
+	if installer.config.AdvertiseRoutes == nil {
+		t.Error("Expected AdvertiseRoutes to be initialized by defaults")
+	}
+}
+
+func installerStringPtr(s string) *string {
+	return &s
+}

--- a/v1/internal/config/network_test.go
+++ b/v1/internal/config/network_test.go
@@ -267,6 +267,49 @@ func TestConfig_ValidateVIPUniqueness(t *testing.T) {
 			wantErr: true,
 			errMsg:  "conflicts with host",
 		},
+		{
+			// Regression: uniqueness used to be gated on Network != nil, so a
+			// config with no network block skipped the check entirely and let
+			// the VIP collide with a control plane host. The check reads only
+			// Hosts, so it must apply regardless of the network block.
+			name: "VIP conflicts with control plane host when network block is absent",
+			config: Config{
+				Hosts: []*host.Host{
+					{
+						Hostname: "node1",
+						Address:  "192.168.1.20",
+						Roles:    []string{host.RoleClusterControlPlane},
+					},
+				},
+				Cluster: ClusterConfig{
+					Name:          "test",
+					PrimaryDomain: "example.com",
+					VIP:           "192.168.1.20", // Conflicts with control plane node1
+				},
+				Components: ComponentMap{"k3s": ComponentConfig{}},
+			},
+			wantErr: true,
+			errMsg:  "cannot be the same as control plane host",
+		},
+		{
+			name: "VIP is unique when network block is absent",
+			config: Config{
+				Hosts: []*host.Host{
+					{
+						Hostname: "node1",
+						Address:  "192.168.1.20",
+						Roles:    []string{host.RoleClusterControlPlane},
+					},
+				},
+				Cluster: ClusterConfig{
+					Name:          "test",
+					PrimaryDomain: "example.com",
+					VIP:           "192.168.1.100",
+				},
+				Components: ComponentMap{"k3s": ComponentConfig{}},
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/v1/internal/config/types.go
+++ b/v1/internal/config/types.go
@@ -84,8 +84,11 @@ func (c *Config) Validate() error {
 		}
 	}
 
-	// Cross-validation: K8s VIP must be unique (not in any host list)
-	if c.Network != nil && c.Cluster.VIP != "" {
+	// Cross-validation: K8s VIP must be unique (not in any host list).
+	// This depends only on c.Hosts, so it applies whether or not a network
+	// block is present - a VIP that collides with a host IP breaks kube-vip
+	// ARP advertisement regardless of how the network is configured.
+	if c.Cluster.VIP != "" {
 		if err := c.validateK8sVIPUniqueness(); err != nil {
 			return err
 		}
@@ -143,10 +146,6 @@ func (m *ManagementConfig) Validate(hosts []*host.Host) error {
 
 // validateK8sVIPUniqueness ensures the K8s VIP is not used by any infrastructure host
 func (c *Config) validateK8sVIPUniqueness() error {
-	if c.Network == nil {
-		return nil
-	}
-
 	vip := c.Cluster.VIP
 
 	// Check against all host addresses


### PR DESCRIPTION
…, test harness v2

- Add Tailscale component scaffolding (types, validation, minimal install)
- Use installerStringPtr to avoid naming conflict with PR 38's stringPtr
- Add allowCGNAT field to vip_test.go struct
- Add test-local.sh with bash array TEST_PKGS for proper package handling
- Add scripts/README.md documentation

Preserves Tailscale as optional with no credentials required for existing users.